### PR TITLE
Fixes bug that was breaking POST to contacts:

### DIFF
--- a/resources/trello_utils.py
+++ b/resources/trello_utils.py
@@ -212,7 +212,7 @@ class Board(object):
                 self.labels['id'][_id] = name
 
     def find_card_by_custom_field(self, field, value, many=False):
-        cards = [card for card in self.cards
+        cards = [card for card in self.cards.values()
                  if card.custom_fields
                  and card.custom_fields[field]['value']==value]
         if not cards:


### PR DESCRIPTION
In a previous commit I changed board.cards from a list to a dictionary 
keyed by card.id but the find_card_by_custom_field() expects a list of 
cards not a dictionary. This commit fixes that bug by replacing 
self.cards with self.cards.val() in the method