### PR TITLE
Add Authorization (AuthZ) to endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,10 +48,14 @@ def load_config(app, env):
             env = 'default'
         load_from_env(app)
 
+    if env == 'test':
+        app.config['LOGIN_DISABLED'] = True
+
     app.config['DEPLOY_ENV'] = env
 
 def create_app(env=None):
     app = Flask(__name__)
+
 
     # Initialize app config
     app.config.from_object('defaultcfg')

--- a/resources/Achievement.py
+++ b/resources/Achievement.py
@@ -5,7 +5,7 @@ from models.base_model import db
 from flask_login import login_required
 from auth import (
     refresh_session, 
-    is_authorized, 
+    is_authorized_view,
     unauthorized
 )
 
@@ -23,7 +23,7 @@ class AchievementAll(Resource):
         achievement = Achievement.query.filter_by(contact_id=contact_id)
         achievement_list = achievements_schema.dump(achievement)
 
-        if not is_authorized(contact_id, 'view'): 
+        if not is_authorized_view(contact_id): 
             return unauthorized()
 
         return {'status': 'success', 'data': achievement_list}, 200

--- a/resources/Achievement.py
+++ b/resources/Achievement.py
@@ -2,13 +2,28 @@ from flask_restful import Resource, request
 from models.achievement_model import Achievement, AchievementSchema
 from models.base_model import db
 
+from flask_login import login_required
+from auth import (
+    refresh_session, 
+    is_authorized, 
+    unauthorized
+)
+
+
 achievement_schema = AchievementSchema()
 achievements_schema = AchievementSchema(many=True)
 
 
 class AchievementAll(Resource):
+    method_decorators = {
+        'get': [login_required, refresh_session],
+    }
 
     def get(self, contact_id):
         achievement = Achievement.query.filter_by(contact_id=contact_id)
         achievement_list = achievements_schema.dump(achievement)
+
+        if not is_authorized(contact_id, 'view'): 
+            return unauthorized()
+
         return {'status': 'success', 'data': achievement_list}, 200

--- a/resources/ProgramContacts.py
+++ b/resources/ProgramContacts.py
@@ -5,6 +5,13 @@ from models.response_model import Response, ResponseSchema
 from models.base_model import db
 from marshmallow import ValidationError
 
+from flask_login import login_required
+from auth import (
+    refresh_session, 
+    is_authorized, 
+    unauthorized
+)
+
 program_contact_schema = ProgramContactSchema()
 program_contacts_schema = ProgramContactSchema(many=True)
 
@@ -34,13 +41,22 @@ def create_program_contact(contact_id, program_id=1, **data):
     return  result
 
 class ProgramContactAll(Resource):
+    method_decorators = {
+        'get': [login_required, refresh_session],
+        'post': [login_required, refresh_session],
+    }
 
     def get(self,contact_id):
+        if not is_authorized_view(contact_id): 
+            return unauthorized()
+
         program_contacts = ProgramContact.query.filter_by(contact_id=contact_id)
         result = program_contacts_schema.dump(program_contacts)
         return {'status': 'success', 'data': result}, 200
 
     def post(self, contact_id):
+        if not is_authorized_write(contact_id): 
+            return unauthorized()
 
         #retrieve and parse request data
         json_data = request.get_json(force=True)
@@ -58,9 +74,15 @@ class ProgramContactAll(Resource):
         return {"status": 'success', 'data': result}, 201
 
 class ProgramContactOne(Resource):
-
+    method_decorators = {
+        'get': [login_required, refresh_session],
+        'post': [login_required, refresh_session],
+    }
 
     def get(self, contact_id, program_id):
+        if not is_authorized_view(contact_id): 
+            return unauthorized()
+
         program_contact = query_one_program_contact(contact_id, program_id)
         if not program_contact:
             return {'message': 'Record does not exist'}, 404
@@ -68,6 +90,8 @@ class ProgramContactOne(Resource):
         return {'status': 'success', 'data': result}, 200
 
     def put(self, contact_id, program_id):
+        if not is_authorized_write(contact_id): 
+            return unauthorized()
 
         #retreives and parses request data
         json = request.get_json(force=True)
@@ -97,6 +121,9 @@ class ProgramContactOne(Resource):
         return {"status": 'success', 'data': result}, 200
 
     def delete(self, contact_id, program_id):
+        if not is_authorized_write(contact_id): 
+            return unauthorized()
+
         program_contact = query_one_program_contact(contact_id, program_id)
         if not program_contact:
             return {'message': 'Program contact does not exist'}, 404

--- a/resources/ProgramContacts.py
+++ b/resources/ProgramContacts.py
@@ -8,7 +8,9 @@ from marshmallow import ValidationError
 from flask_login import login_required
 from auth import (
     refresh_session, 
-    is_authorized, 
+    is_authorized_view, 
+    is_authorized_write, 
+
     unauthorized
 )
 

--- a/resources/Resume.py
+++ b/resources/Resume.py
@@ -14,7 +14,9 @@ from pprint import pprint
 from flask_login import login_required
 from auth import (
     refresh_session, 
-    is_authorized, 
+    is_authorized_view, 
+    is_authorized_write, 
+
     unauthorized
 )
 

--- a/resources/Resume.py
+++ b/resources/Resume.py
@@ -11,6 +11,14 @@ from marshmallow import ValidationError
 import datetime as dt
 from pprint import pprint
 
+from flask_login import login_required
+from auth import (
+    refresh_session, 
+    is_authorized, 
+    unauthorized
+)
+
+
 resumes_schema = ResumeSchema(many=True)
 resume_schema = ResumeSchema()
 resume_generate_schema = ResumeSchemaNew()
@@ -20,8 +28,15 @@ resume_sections_schema = ResumeSectionSchema(many=True)
 resume_section_schema = ResumeSectionSchema()
 
 class GenerateResume(Resource):
+    method_decorators = {
+        'post': [login_required, refresh_session],
+    }
+
 
     def post(self, contact_id):
+        if not is_authorized_write(contact_id): 
+            return unauthorized()
+
         #load the input data
         input_data = request.get_json(force=True)
         try:
@@ -79,13 +94,23 @@ class GenerateResume(Resource):
         return {'status': 'success', 'data': result}, 201
 
 class ResumeAll(Resource):
+    method_decorators = {
+        'get': [login_required, refresh_session],
+        'post': [login_required, refresh_session],
+    }
 
     def get(self, contact_id):
+        if not is_authorized_view(contact_id): 
+            return unauthorized()
+
         res = Resume.query.filter_by(contact_id=contact_id)
         res_list = resumes_schema.dump(res)
         return {'status': 'success', 'data': res_list}, 200
 
     def post(self, contact_id):
+        if not is_authorized_write(contact_id): 
+            return unauthorized()
+
         json_data = request.get_json(force=True)
         try:
             data = resume_schema.load(json_data)
@@ -100,11 +125,20 @@ class ResumeAll(Resource):
         return {'status': 'success', 'data': result}, 201
 
 class ResumeOne(Resource):
+    method_decorators = {
+        'get': [login_required, refresh_session],
+        'post': [login_required, refresh_session],
+        'delete': [login_required, refresh_session],
+    }
 
     def get(self, resume_id):
         res = Resume.query.get(resume_id)
         if not res:
             return {'message': 'Resume does not exist'}, 404
+
+        if not is_authorized_view(res.contact.id): 
+            return unauthorized()
+
         result = resume_schema.dump(res)
         return {'status': 'success', 'data': result}, 200
 
@@ -112,6 +146,9 @@ class ResumeOne(Resource):
         res = Resume.query.get(resume_id)
         if not res:
             return {'message': 'Resume does not exist'}, 404
+        if not is_authorized_write(res.contact.id): 
+            return unauthorized()
+
         db.session.delete(res)
         db.session.commit()
         return {'status': 'success'}, 200
@@ -120,6 +157,9 @@ class ResumeOne(Resource):
         res = Resume.query.get(resume_id)
         if not res:
             return {'message': 'Resume does not exist'}, 404
+        if not is_authorized_write(res.contact.id): 
+            return unauthorized()
+
         json_data = request.get_json(force=True)
         try:
             data = resume_schema.load(json_data, partial=True)
@@ -134,12 +174,29 @@ class ResumeOne(Resource):
         return {'status': 'success', 'data': result}, 200
 
 class ResumeSectionAll(Resource):
+    method_decorators = {
+        'get': [login_required, refresh_session],
+        'post': [login_required, refresh_session],
+    }
+
     def get(self, resume_id):
+        res = Resume.query.get(resume_id)
+        if not res:
+            return {'message': 'Resume does not exist'}, 404
+        if not is_authorized_view(res.contact.id): 
+            return unauthorized()
+
         sections = ResumeSection.query.filter_by(resume_id=resume_id)
         result = resume_sections_schema.dump(sections)
         return {'status': 'success', 'data': result}, 200
 
     def post(self, resume_id):
+        res = Resume.query.get(resume_id)
+        if not res:
+            return {'message': 'Resume does not exist'}, 404
+        if not is_authorized_write(res.contact.id): 
+            return unauthorized()
+
         json_data = request.get_json(force=True)
         try:
             data = resume_section_schema.load(json_data)
@@ -160,8 +217,19 @@ class ResumeSectionAll(Resource):
         return {'status': 'success', 'data': result}, 201
 
 class ResumeSectionOne(Resource):
+    method_decorators = {
+        'get': [login_required, refresh_session],
+        'put': [login_required, refresh_session],
+        'delete': [login_required, refresh_session],
+    }
 
     def get(self, resume_id, section_id):
+        res = Resume.query.get(resume_id)
+        if not res:
+            return {'message': 'Resume does not exist'}, 404
+        if not is_authorized_view(res.contact.id): 
+            return unauthorized()
+
         section = ResumeSection.query.get(section_id)
         if not section:
             return {'message': 'Resume section does not exist'}, 404
@@ -169,6 +237,12 @@ class ResumeSectionOne(Resource):
         return {'status': 'success', 'data': result}, 200
 
     def put(self, resume_id, section_id):
+        res = Resume.query.get(resume_id)
+        if not res:
+            return {'message': 'Resume does not exist'}, 404
+        if not is_authorized_write(res.contact.id): 
+            return unauthorized()
+
         section = ResumeSection.query.get(section_id)
         if not section:
             return {'message': 'Resume section does not exist'}, 404
@@ -193,6 +267,12 @@ class ResumeSectionOne(Resource):
         return {'status': 'success', 'data': result}, 200
 
     def delete(self, resume_id, section_id):
+        res = Resume.query.get(resume_id)
+        if not res:
+            return {'message': 'Resume does not exist'}, 404
+        if not is_authorized_write(res.contact.id): 
+            return unauthorized()
+
         section = ResumeSection.query.get(section_id)
         if not section:
             return {'message': 'Resume section does not exist'}, 404

--- a/resources/Skills.py
+++ b/resources/Skills.py
@@ -8,7 +8,8 @@ from .skill_utils import make_skill, get_skill_id, normalize_skill_name, complet
 from flask_login import login_required
 from auth import (
     refresh_session, 
-    is_authorized, 
+    is_authorized_view, 
+    is_authorized_write, 
     unauthorized
 )
 

--- a/resources/Tag.py
+++ b/resources/Tag.py
@@ -5,6 +5,15 @@ from models.contact_model import Contact, ContactSchema
 from models.base_model import db
 from marshmallow import ValidationError
 
+from flask_login import login_required
+from auth import (
+    refresh_session, 
+    is_authorized_view, 
+    is_authorized_write, 
+    unauthorized
+)
+
+
 # Useful for debugging
 #from flask_sqlalchemy import get_debug_queries
 #from pprint import pprint
@@ -41,6 +50,7 @@ class TagAll(Resource):
 # Returns a specific tag
 class TagOne(Resource):
 
+
     def get(self, tag_id):
         tag = Tag.query.get(tag_id)
         if not tag:
@@ -75,8 +85,17 @@ class TagOne(Resource):
 
 
 class TagItemAll(Resource):
+    method_decorators = {
+        'get': [login_required, refresh_session],
+        'post': [login_required, refresh_session],
+    }
+
+
     # returns a list of tags associated with a given contact
     def get(self, contact_id):
+        if not is_authorized_view(contact_id): 
+            return unauthorized()
+
         type_arg = request.args.get('type')
         if type_arg:
             if type_arg not in TagType.__members__:
@@ -92,6 +111,9 @@ class TagItemAll(Resource):
         return {'status': 'success', 'data': tags_list}, 200
 
     def post(self, contact_id):
+        if not is_authorized_write(contact_id): 
+            return unauthorized()
+
         json_data = request.get_json(force=True)
         try:
             data = tag_item_schema.load(json_data)
@@ -106,7 +128,16 @@ class TagItemAll(Resource):
         return {'status': 'success', 'data': result}, 201
 
 class TagItemOne(Resource):
+    method_decorators = {
+        'get': [login_required, refresh_session],
+        'put': [login_required, refresh_session],
+        'delete': [login_required, refresh_session],
+    }
+
     def get(self, contact_id, tag_id):
+        if not is_authorized_view(contact_id): 
+            return unauthorized()
+
         tag = (TagItem.query.filter_by(contact_id=contact_id, tag_id=tag_id)
                             .first())
         if not tag:
@@ -115,6 +146,9 @@ class TagItemOne(Resource):
         return {'status': 'success', 'data': tag_data}, 200
 
     def put(self, contact_id, tag_id):
+        if not is_authorized_write(contact_id): 
+            return unauthorized()
+
         tag = (TagItem.query.filter_by(contact_id=contact_id, tag_id=tag_id)
                             .first())
         if not tag:
@@ -133,6 +167,9 @@ class TagItemOne(Resource):
         return {'status': 'success', 'data': result}, 200
 
     def delete(self, contact_id, tag_id):
+        if not is_authorized_write(contact_id): 
+            return unauthorized()
+
         tag = TagItem.query.filter_by(contact_id=contact_id, tag_id=tag_id).first()
         if not tag:
             return {'message': 'TagItem does not exist'}, 404

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def _app(request):
     app.config['DEBUG'] = True
     app.config['TESTING'] = True
     app.config['CONTACT_DELETE_TOKEN'] = 'testing_token'
+
     with Postgresql() as postgresql:
         app.config['SQLALCHEMY_DATABASE_URI'] = postgresql.url()
 


### PR DESCRIPTION
This update is the one that actually locks down our API (replaces the "privacy screen" level of security we've had so far with an actual locked door)

It adds a requirement that a user is logged in to nearly all the endpoints, and also checks if they are authorized to see this. It allows for staff users, who can see all users (but not edit their information). The `is_authorized_*` functions are the key to all this, as you can see in the code.

The other key here is the sessions functionality, which relays the information about whether or not the user is logged in, as well as keeping track of their permissions for the session.

This pull request on the frontend needs to be deployed before this PR to avoid breaking everything, because it modifies the frontend to send cookies on every request: https://github.com/baltimorecorps/hippo-frontend/pull/69