### PR TITLE
Contact eligibility

### DIFF
--- a/api.py
+++ b/api.py
@@ -9,12 +9,13 @@ from resources.Resume import ResumeSectionAll, ResumeSectionOne
 from resources.Skills import ContactSkills, ContactSkillOne, AutocompleteSkill
 from resources.Session import Session
 from resources.ProgramContacts import ProgramContactOne, ProgramContactAll
-from resources.Trello_Intake_Talent import (
-    IntakeTalentBoard,
-    IntakeTalentCard
-)
+from resources.Trello_Intake_Talent import IntakeTalentBoard, IntakeTalentCard
 from resources.Opportunity import OpportunityAll, OpportunityOne
-from resources.OpportunityApp import OpportunityAppOne, OpportunityAppSubmit
+from resources.OpportunityApp import (
+    OpportunityAppAll,
+    OpportunityAppOne,
+    OpportunityAppSubmit
+)
 from resources.FormAssembly import (
     TalentProgramApp,
     OpportunityIntakeApp,
@@ -90,7 +91,9 @@ api.add_resource(OpportunityAppOne,
 api.add_resource(OpportunityAppSubmit,
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>/submit',
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>/submit/')
-
+api.add_resource(OpportunityAppAll,
+                 '/contacts/<int:contact_id>/app',
+                 '/contacts/<int:contact_id>/app/')
 
 api.add_resource(IntakeTalentBoard,
                  '/programs/<int:program_id>/trello/intake-talent',
@@ -113,5 +116,3 @@ api.add_resource(OpportunityAll,
 api.add_resource(OpportunityOne,
                  '/opportunity/<string:opportunity_id>',
                  '/opportunity/<string:opportunity_id>/')
-
-

--- a/models/cycle_model.py
+++ b/models/cycle_model.py
@@ -19,6 +19,8 @@ class Cycle(db.Model):
 
     #relationship fields
     program = db.relationship('Program', back_populates='cycles')
+    opportunities = db.relationship('Opportunity', back_populates='cycle',
+                                    cascade='all, delete, delete-orphan')
 
     #calculated fields
     @hybrid_property

--- a/models/opportunity_model.py
+++ b/models/opportunity_model.py
@@ -1,4 +1,5 @@
 from models.base_model import db
+from models.cycle_model import Cycle, CycleSchema
 from marshmallow import Schema, fields, EXCLUDE
 from marshmallow_enum import EnumField
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -17,6 +18,7 @@ class Opportunity(db.Model):
 
     #table columns
     id = db.Column(db.String, primary_key=True)
+    cycle_id = db.Column(db.Integer, db.ForeignKey('cycle.id'), nullable=False)
     title = db.Column(db.String(200), nullable=False)
     short_description = db.Column(db.String(2000), nullable=False)
     gdoc_id = db.Column(db.String(200), nullable=False)
@@ -24,8 +26,10 @@ class Opportunity(db.Model):
     stage = db.Column(db.Integer, default=1)
     org_name = db.Column(db.String(255), nullable=False)
 
+    #relationships
     applications = db.relationship('OpportunityApp', back_populates='opportunity',
                                    cascade='all, delete, delete-orphan')
+    cycle = db.relationship('Cycle', back_populates='opportunities')
 
     @hybrid_property
     def status(self):
@@ -38,6 +42,8 @@ class OpportunitySchema(Schema):
     gdoc_id = fields.String(required=True)
     status = EnumField(OpportunityStage, dump_only=True)
     org_name = fields.String(dump_only=True)
+    cycle_id = fields.Integer(dump_only=True)
+    program_id = fields.Integer(attribute='cycle.program_id', dump_only=True)
 
     class Meta:
         unknown = EXCLUDE

--- a/models/opportunity_model.py
+++ b/models/opportunity_model.py
@@ -22,6 +22,7 @@ class Opportunity(db.Model):
     gdoc_id = db.Column(db.String(200), nullable=False)
     card_id = db.Column(db.String, nullable=False)
     stage = db.Column(db.Integer, default=1)
+    org_name = db.Column(db.String(255), nullable=False)
 
     applications = db.relationship('OpportunityApp', back_populates='opportunity',
                                    cascade='all, delete, delete-orphan')
@@ -36,6 +37,7 @@ class OpportunitySchema(Schema):
     short_description = fields.String(required=True)
     gdoc_id = fields.String(required=True)
     status = EnumField(OpportunityStage, dump_only=True)
+    org_name = fields.String(dump_only=True)
 
     class Meta:
         unknown = EXCLUDE

--- a/models/program_contact_model.py
+++ b/models/program_contact_model.py
@@ -31,7 +31,8 @@ class ProgramContact(db.Model):
     # https://medium.com/@s.azad4/modifying-python-objects-within-the-sqlalchemy-framework-7b6c8dd71ab3
     def update(self, **update_dict):
         for field, value in update_dict.items():
-            setattr(self, field, value)
+            if field in UPDATE_FIELDS:
+                setattr(self, field, value)
         db.session.commit()
 
 class ProgramContactSchema(Schema):

--- a/models/program_contact_model.py
+++ b/models/program_contact_model.py
@@ -40,13 +40,11 @@ class ProgramContactSchema(Schema):
     contact_id = fields.Integer()
     program_id = fields.Integer(load_only=True)
     program = fields.Nested(ProgramSchema, dump_only=True)
-    responses = fields.Nested(ResponseSchema, many=True)
     card_id = fields.String()
     stage = fields.Integer()
     is_approved = fields.Boolean()
     is_active = fields.Boolean()
-    reviews = fields.Nested(ReviewSchema, many=True, dump_only=True,
-                            cascade='all, delete, delete-orphan')
+    reviews = fields.Nested(ReviewSchema, many=True, dump_only=True)
 
     class Meta:
         unknown = EXCLUDE

--- a/models/program_model.py
+++ b/models/program_model.py
@@ -23,7 +23,6 @@ class Program(db.Model):
 class ProgramSchema(Schema):
     id = fields.Integer(dump_only=True)
     name = fields.String(required=True)
-    questions = fields.Nested(QuestionSchema, many=True)
     current_cycle = fields.Nested(CycleSchema)
 
     class Meta:

--- a/resources/FormAssembly.py
+++ b/resources/FormAssembly.py
@@ -46,7 +46,8 @@ class OpportunityIntakeApp(Resource):
             'short_description': '',
             'gdoc_id': form_data['google_doc_id'],
             'card_id': opp_card.id,
-            'stage': OpportunityStage.submitted.value
+            'stage': OpportunityStage.submitted.value,
+            'org_name': form_data['org']
         }
         opp = create_new_opportunity(opp_data)
         opp_card.set_custom_field_values(**{'Opp ID': opp.id})

--- a/resources/FormAssembly.py
+++ b/resources/FormAssembly.py
@@ -26,6 +26,10 @@ def get_review_talent_board_id(program_id):
     program = Program.query.get(program_id)
     return program.current_cycle.review_talent_board_id
 
+def get_current_cycle_id(program_id):
+    program = Program.query.get(program_id)
+    return program.current_cycle.id
+
 def find_opp_card(form_data):
     board_id = get_matching_opp_board_id(form_data['program_id'])
     board_data = query_board_data(board_id)
@@ -47,7 +51,8 @@ class OpportunityIntakeApp(Resource):
             'gdoc_id': form_data['google_doc_id'],
             'card_id': opp_card.id,
             'stage': OpportunityStage.submitted.value,
-            'org_name': form_data['org']
+            'org_name': form_data['org'],
+            'cycle_id': get_current_cycle_id(form_data['program_id'])
         }
         opp = create_new_opportunity(opp_data)
         opp_card.set_custom_field_values(**{'Opp ID': opp.id})

--- a/resources/OpportunityApp.py
+++ b/resources/OpportunityApp.py
@@ -26,7 +26,8 @@ class OpportunityAppAll(Resource):
         if not is_authorized_view(contact_id):
             return unauthorized()
         opportunity_apps = (OpportunityApp.query
-            .filter_by(contact_id=contact_id)
+            .filter(OpportunityApp.contact_id==contact_id,
+                    OpportunityApp.stage>=ApplicationStage.submitted.value)
             .all())
         if not opportunity_apps:
             return {'message': 'No applications found'}, 404
@@ -50,7 +51,7 @@ class OpportunityAppOne(Resource):
 
         if not opportunity_app:
             return {'message': 'Application does not exist'}, 404
-        
+
 
         data = opportunity_app_schema.dump(opportunity_app)
         return {'status': 'success', 'data': data}, 200

--- a/resources/OpportunityApp.py
+++ b/resources/OpportunityApp.py
@@ -7,14 +7,31 @@ from flask_login import login_required
 from models.base_model import db
 
 from auth import (
-    is_authorized_view, 
-    is_authorized_write, 
-    unauthorized, 
+    is_authorized_view,
+    is_authorized_write,
+    unauthorized,
     refresh_session
 )
 from models.opportunity_app_model import OpportunityApp, OpportunityAppSchema, ApplicationStage
 
 opportunity_app_schema = OpportunityAppSchema()
+opportunity_app_schema_many = OpportunityAppSchema(many=True)
+
+class OpportunityAppAll(Resource):
+    method_decorators = {
+        'get': [login_required, refresh_session]
+    }
+
+    def get(self, contact_id):
+        if not is_authorized_view(contact_id):
+            return unauthorized()
+        opportunity_apps = (OpportunityApp.query
+            .filter_by(contact_id=contact_id)
+            .all())
+        if not opportunity_apps:
+            return {'message': 'No applications found'}, 404
+        data = opportunity_app_schema_many.dump(opportunity_apps)
+        return {'status': 'success', 'data': data}, 200
 
 class OpportunityAppOne(Resource):
     method_decorators = {
@@ -86,7 +103,7 @@ class OpportunityAppOne(Resource):
         db.session.commit()
         result = opportunity_app_schema.dump(opportunity_app)
         return {'status': 'success', 'data': result}, 200
-        
+
 class OpportunityAppSubmit(Resource):
     method_decorators = {
         'post': [login_required, refresh_session],
@@ -109,8 +126,3 @@ class OpportunityAppSubmit(Resource):
         db.session.commit()
         result = opportunity_app_schema.dump(opportunity_app)
         return {'status': 'success', 'data': result}, 200
-     
-
-
-
-

--- a/resources/ProgramContacts.py
+++ b/resources/ProgramContacts.py
@@ -31,12 +31,9 @@ def create_program_contact(contact_id, program_id=1, **data):
     program_contact = query_one_program_contact(contact_id, program_id)
     if program_contact:
         return {'message': 'Record already exists'}, 400
-    responses = data.pop('responses', None)
     data['contact_id'] = contact_id
     data['program_id'] = program_id
     program_contact = ProgramContact(**data)
-    if responses:
-        add_responses(responses, program_contact)
     db.session.add(program_contact)
     db.session.commit()
     result = program_contact_schema.dump(program_contact)
@@ -110,15 +107,8 @@ class ProgramContactOne(Resource):
         if not program_contact:
             return {'message': 'Record does not exist'}, 404
 
-        # updates program_contact record and related response records
-        responses = data.pop('responses', None)
-        for k,v in data.items():
-            if k in UPDATE_FIELDS:
-                setattr(program_contact, k, v)
-        if responses:
-            del program_contact.responses[:]
-            add_responses(responses, program_contact)
-
+        # updates program_contact record
+        program_contact.update(**data)
         db.session.commit()
         result = program_contact_schema.dump(program_contact)
         return {"status": 'success', 'data': result}, 200

--- a/tests/populate_db.py
+++ b/tests/populate_db.py
@@ -281,6 +281,7 @@ test_opp1 = Opportunity(
     short_description="This is a test opportunity.",
     gdoc_id="ABC123xx==",
     card_id="card",
+    org_name="Test Org",
 )
 
 test_opp2 = Opportunity(
@@ -289,6 +290,7 @@ test_opp2 = Opportunity(
     short_description="This is another test opportunity.",
     gdoc_id="BBB222xx==",
     card_id="card",
+    org_name="Test Org",
 )
 
 app_billy = OpportunityApp(

--- a/tests/populate_db.py
+++ b/tests/populate_db.py
@@ -251,6 +251,7 @@ billy_pfp = ProgramContact(
     contact_id=123,
     card_id='card',
     stage=1,
+    is_approved=True
 )
 
 r_billy1 = Response(
@@ -282,6 +283,7 @@ test_opp1 = Opportunity(
     gdoc_id="ABC123xx==",
     card_id="card",
     org_name="Test Org",
+    cycle_id=2,
 )
 
 test_opp2 = Opportunity(
@@ -291,6 +293,7 @@ test_opp2 = Opportunity(
     gdoc_id="BBB222xx==",
     card_id="card",
     org_name="Test Org",
+    cycle_id=2,
 )
 
 app_billy = OpportunityApp(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -82,11 +82,7 @@ PROGRAMS = {
     'pfp': {
         'id': 1,
         'name': 'Place for Purpose',
-        'current_cycle': CYCLES['pfp'],
-        'questions': [
-            QUESTIONS['q_pfp1'],
-            QUESTIONS['q_pfp2'],
-        ]
+        'current_cycle': CYCLES['pfp']
     }
 }
 
@@ -123,14 +119,22 @@ PROGRAM_CONTACTS = {
         'card_id': 'card',
         'stage': 1,
         'is_active': True,
-        'is_approved': False,
-        'responses': [
-            RESPONSES['r_billy1'],
-            RESPONSES['r_billy2']
-        ],
+        'is_approved': True,
         'reviews': [
             REVIEWS['review_billy']
         ]
+    }
+}
+
+ELIGIBILITY = {
+    'billy_pfp': {
+        'id': 5,
+        'contact_id': 123,
+        'program_id': 1,
+        'cycles': [2],
+        'stage': 1,
+        'is_active': True,
+        'is_approved': True,
     }
 }
 
@@ -765,10 +769,11 @@ def test_post_formassembly_opportunity_intake(app):
       lambda: ProgramContact.query.get(5),
       lambda r: r.stage == 2,
       )
-    ,('/api/contacts/123/programs/1/',
+    ,pytest.param('/api/contacts/123/programs/1/',
       {'responses': [RESPONSES['r_billy1']]},
       lambda: ProgramContact.query.get(5),
-      lambda r: len(r.responses) == 1 and r.responses[0].response_text == 'Race and equity answer'
+      lambda r: len(r.responses) == 1 and r.responses[0].response_text == 'Race and equity answer',
+      marks=pytest.mark.skip
       )
     ,pytest.param('/api/opportunity/123abc/',
       {'title': "New title"},
@@ -993,6 +998,7 @@ def test_get_autocomplete(app):
     ,('/api/contacts/123/programs/', [PROGRAM_CONTACTS['billy_pfp']])
     ,('/api/opportunity/', OPPORTUNITIES.values())
     ,('/api/contacts/123/app/', [APPLICATIONS['app_billy']])
+    ,('/api/contacts/123/eligibility/', ELIGIBILITY.values())
     ]
 )
 def test_get_many_unordered(app, url, expected):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -146,6 +146,8 @@ OPPORTUNITIES = {
         'gdoc_id': "ABC123xx==",
         'status': 'submitted',
         'org_name': 'Test Org',
+        'cycle_id': 2,
+        'program_id': 1
     },
     'test_opp2': {
         'id': '222abc',
@@ -154,6 +156,8 @@ OPPORTUNITIES = {
         'gdoc_id': "BBB222xx==",
         'status': 'submitted',
         'org_name': 'Test Org',
+        'cycle_id': 2,
+        'program_id': 1
     },
 
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1002,7 +1002,6 @@ def test_get_autocomplete(app):
     ,('/api/contacts/123/programs/', [PROGRAM_CONTACTS['billy_pfp']])
     ,('/api/opportunity/', OPPORTUNITIES.values())
     ,('/api/contacts/123/app/', [APPLICATIONS['app_billy']])
-    ,('/api/contacts/123/eligibility/', ELIGIBILITY.values())
     ]
 )
 def test_get_many_unordered(app, url, expected):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -992,7 +992,7 @@ def test_get_autocomplete(app):
     ,('/api/contacts/123/resumes/', RESUMES.values())
     ,('/api/contacts/123/programs/', [PROGRAM_CONTACTS['billy_pfp']])
     ,('/api/opportunity/', OPPORTUNITIES.values())
-    ,('/api/contacts/123/app/', APPLICATIONS.values())
+    ,('/api/contacts/123/app/', [APPLICATIONS['app_billy']])
     ]
 )
 def test_get_many_unordered(app, url, expected):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -141,6 +141,7 @@ OPPORTUNITIES = {
         'short_description': "This is a test opportunity.",
         'gdoc_id': "ABC123xx==",
         'status': 'submitted',
+        'org_name': 'Test Org',
     },
     'test_opp2': {
         'id': '222abc',
@@ -148,6 +149,7 @@ OPPORTUNITIES = {
         'short_description': "This is another test opportunity.",
         'gdoc_id': "BBB222xx==",
         'status': 'submitted',
+        'org_name': 'Test Org',
     },
 
 }
@@ -990,6 +992,7 @@ def test_get_autocomplete(app):
     ,('/api/contacts/123/resumes/', RESUMES.values())
     ,('/api/contacts/123/programs/', [PROGRAM_CONTACTS['billy_pfp']])
     ,('/api/opportunity/', OPPORTUNITIES.values())
+    ,('/api/contacts/123/app/', APPLICATIONS.values())
     ]
 )
 def test_get_many_unordered(app, url, expected):

--- a/tests/trello_integration_test.py
+++ b/tests/trello_integration_test.py
@@ -9,7 +9,6 @@ from models.resume_model import Resume
 from models.resume_section_model import ResumeSection
 from models.tag_model import Tag
 from models.tag_item_model import TagItem
-from models.skill_model import SkillItem
 from models.program_contact_model import ProgramContact
 from models.session_model import UserSession
 from models.opportunity_model import Opportunity


### PR DESCRIPTION
Merges contact-eligibility into master for deployment, which does the following: 

- Adds `cycle_id` to opportunity table
- Adds `cycle_id` and `program_id` to opportunity schema
- Sets `cycle_id` in the POST method of the OpportunityIntake resource
- Removes responses from the program_contact schema
- Removes questions from the program schema

Considerations for deployment:

- **Heroku Variables:** N/A
- **DB Migrations:** Yes
- **Deployment Sequence:** Deploy backend before frontend
- **Auth Changes:** N/A