### PR TITLE
Add gdoc link to opps

### DIFF
--- a/models/opportunity_model.py
+++ b/models/opportunity_model.py
@@ -19,8 +19,9 @@ class Opportunity(db.Model):
     id = db.Column(db.String, primary_key=True)
     title = db.Column(db.String(200), nullable=False)
     short_description = db.Column(db.String(2000), nullable=False)
-    gdoc_id = db.Column(db.String(200), nullable=False)
-    card_id = db.Column(db.String, nullable=False)
+    gdoc_id = db.Column(db.String(200))
+    gdoc_link = db.Column(db.String(200), nullable=False)
+    card_id = db.Column(db.String)
     stage = db.Column(db.Integer, default=1)
 
     applications = db.relationship('OpportunityApp', back_populates='opportunity',
@@ -34,7 +35,8 @@ class OpportunitySchema(Schema):
     id = fields.String(required=True, dump_only=True)
     title = fields.String(required=True)
     short_description = fields.String(required=True)
-    gdoc_id = fields.String(required=True)
+    gdoc_id = fields.String()
+    gdoc_link = fields.String(required=True)
     status = EnumField(OpportunityStage, dump_only=True)
 
     class Meta:

--- a/resources/FormAssembly.py
+++ b/resources/FormAssembly.py
@@ -41,12 +41,15 @@ class OpportunityIntakeApp(Resource):
         opp_card, board = find_opp_card(form_data)
         if opp_card is None:
             return {'message': 'No card found'}, 404
+        gdoc_id = form_data['google_doc_id']
+        gdoc_link = f'https://docs.google.com/document/d/{gdoc_id}/edit'
         opp_data = {
             'title': form_data['title'],
             'short_description': '',
-            'gdoc_id': form_data['google_doc_id'],
+            'gdoc_id': gdoc_id,
             'card_id': opp_card.id,
-            'stage': OpportunityStage.submitted.value
+            'stage': OpportunityStage.submitted.value,
+            'gdoc_link': gdoc_link
         }
         opp = create_new_opportunity(opp_data)
         opp_card.set_custom_field_values(**{'Opp ID': opp.id})

--- a/tests/populate_db.py
+++ b/tests/populate_db.py
@@ -338,6 +338,7 @@ test_opp1 = Opportunity(
     short_description="This is a test opportunity.",
     gdoc_id="ABC123xx==",
     card_id="card",
+    gdoc_link="https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit"
 )
 
 test_opp2 = Opportunity(
@@ -346,6 +347,7 @@ test_opp2 = Opportunity(
     short_description="This is another test opportunity.",
     gdoc_id="BBB222xx==",
     card_id="card",
+    gdoc_link="https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit"
 )
 
 app_billy = OpportunityApp(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -193,6 +193,7 @@ OPPORTUNITIES = {
         'title': "Test Opportunity",
         'short_description': "This is a test opportunity.",
         'gdoc_id': "ABC123xx==",
+        'gdoc_link': "https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit",
         'status': 'submitted',
     },
     'test_opp2': {
@@ -200,6 +201,7 @@ OPPORTUNITIES = {
         'title': "Another Test Opportunity",
         'short_description': "This is another test opportunity.",
         'gdoc_id': "BBB222xx==",
+        'gdoc_link': "https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit",
         'status': 'submitted',
     },
 
@@ -560,6 +562,7 @@ POSTS = {
         "title": "Test Opportunity",
         "short_description": "We are looking for a tester to test our application by taking this test opportunity. Testers of all experience welcome",
         "gdoc_id": "TESTABC11==",
+        "gdoc_link": "https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit"
     },
 }
 
@@ -615,10 +618,9 @@ def post_request(app, url, data):
       marks=pytest.mark.skip
       # TODO: unskip when trello stuff is mocked out
       )
-    ,pytest.param('/api/opportunity/',
+    ,('/api/opportunity/',
       POSTS['opportunity'],
-      lambda id: Opportunity.query.filter_by(title="Test Opportunity").first(),
-      marks=pytest.mark.skip
+      lambda id: Opportunity.query.filter_by(title="Test Opportunity").first()
       )
     ,pytest.param('/api/contacts/124/app/123abc/',
       {},


### PR DESCRIPTION
Merges add-gdoc-link-to-opps feature branch to master for deployment:

- Adds `gdoc_link` to opportunity table and schema as a required column/field
- Makes 'gdoc_id` nullable in the table and optional in the schema
- Makes 'card_id` nullable in the table and optional in the schema

Considerations for deployment:

- **DB Migrations:** Yes
- **Heroku Variables:** N/A
- **Deployment sequence:** Backend before frontend
- **AuthN/AuthZ Changes:** N/A