### PR TITLE
Staff post opportunities

### DIFF
--- a/api.py
+++ b/api.py
@@ -8,8 +8,8 @@ from resources.Resume import ResumeAll, ResumeOne, GenerateResume
 from resources.Resume import ResumeSectionAll, ResumeSectionOne
 from resources.Skills import ContactSkills, ContactSkillOne, AutocompleteSkill
 from resources.Capability import (
-    CapabilityRecommended, 
-    ContactCapabilities, 
+    CapabilityRecommended,
+    ContactCapabilities,
     ContactCapabilitySuggestions,
     ContactCapabilitySuggestionOne,
 )
@@ -21,7 +21,11 @@ from resources.Trello_Intake_Talent import (
     ReviewTalentCard
 )
 from resources.Opportunity import OpportunityAll, OpportunityOne
-from resources.OpportunityApp import OpportunityAppOne, OpportunityAppSubmit
+from resources.OpportunityApp import (
+    OpportunityAppAll,
+    OpportunityAppOne,
+    OpportunityAppSubmit
+)
 from resources.FormAssembly import (
     TalentProgramApp,
     OpportunityIntakeApp,
@@ -109,7 +113,9 @@ api.add_resource(OpportunityAppOne,
 api.add_resource(OpportunityAppSubmit,
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>/submit',
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>/submit/')
-
+api.add_resource(OpportunityAppAll,
+                 '/contacts/<int:contact_id>/app',
+                 '/contacts/<int:contact_id>/app/')
 
 api.add_resource(IntakeTalentBoard,
                  '/programs/<int:program_id>/trello/intake-talent',
@@ -135,5 +141,3 @@ api.add_resource(OpportunityAll,
 api.add_resource(OpportunityOne,
                  '/opportunity/<string:opportunity_id>',
                  '/opportunity/<string:opportunity_id>/')
-
-

--- a/models/cycle_model.py
+++ b/models/cycle_model.py
@@ -19,6 +19,8 @@ class Cycle(db.Model):
 
     #relationship fields
     program = db.relationship('Program', back_populates='cycles')
+    opportunities = db.relationship('Opportunity', back_populates='cycle',
+                                    cascade='all, delete, delete-orphan')
 
     #calculated fields
     @hybrid_property

--- a/models/opportunity_model.py
+++ b/models/opportunity_model.py
@@ -1,4 +1,5 @@
 from models.base_model import db
+from models.cycle_model import Cycle, CycleSchema
 from marshmallow import Schema, fields, EXCLUDE
 from marshmallow_enum import EnumField
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -17,15 +18,19 @@ class Opportunity(db.Model):
 
     #table columns
     id = db.Column(db.String, primary_key=True)
+    cycle_id = db.Column(db.Integer, db.ForeignKey('cycle.id'), nullable=False)
     title = db.Column(db.String(200), nullable=False)
     short_description = db.Column(db.String(2000), nullable=False)
     gdoc_id = db.Column(db.String(200))
     gdoc_link = db.Column(db.String(200), nullable=False)
     card_id = db.Column(db.String)
     stage = db.Column(db.Integer, default=1)
+    org_name = db.Column(db.String(255), nullable=False)
 
+    #relationships
     applications = db.relationship('OpportunityApp', back_populates='opportunity',
                                    cascade='all, delete, delete-orphan')
+    cycle = db.relationship('Cycle', back_populates='opportunities')
 
     @hybrid_property
     def status(self):
@@ -38,6 +43,9 @@ class OpportunitySchema(Schema):
     gdoc_id = fields.String()
     gdoc_link = fields.String(required=True)
     status = EnumField(OpportunityStage, dump_only=True)
+    org_name = fields.String(required=True)
+    cycle_id = fields.Integer(required=True)
+    program_id = fields.Integer(attribute='cycle.program_id', dump_only=True)
 
     class Meta:
         unknown = EXCLUDE

--- a/models/opportunity_model.py
+++ b/models/opportunity_model.py
@@ -19,8 +19,9 @@ class Opportunity(db.Model):
     id = db.Column(db.String, primary_key=True)
     title = db.Column(db.String(200), nullable=False)
     short_description = db.Column(db.String(2000), nullable=False)
-    gdoc_id = db.Column(db.String(200), nullable=False)
-    card_id = db.Column(db.String, nullable=False)
+    gdoc_id = db.Column(db.String(200))
+    gdoc_link = db.Column(db.String(200), nullable=False)
+    card_id = db.Column(db.String)
     stage = db.Column(db.Integer, default=1)
 
     applications = db.relationship('OpportunityApp', back_populates='opportunity',
@@ -34,7 +35,8 @@ class OpportunitySchema(Schema):
     id = fields.String(required=True, dump_only=True)
     title = fields.String(required=True)
     short_description = fields.String(required=True)
-    gdoc_id = fields.String(required=True)
+    gdoc_id = fields.String()
+    gdoc_link = fields.String(required=True)
     status = EnumField(OpportunityStage, dump_only=True)
 
     class Meta:

--- a/models/program_contact_model.py
+++ b/models/program_contact_model.py
@@ -31,7 +31,8 @@ class ProgramContact(db.Model):
     # https://medium.com/@s.azad4/modifying-python-objects-within-the-sqlalchemy-framework-7b6c8dd71ab3
     def update(self, **update_dict):
         for field, value in update_dict.items():
-            setattr(self, field, value)
+            if field in UPDATE_FIELDS:
+                setattr(self, field, value)
         db.session.commit()
 
 class ProgramContactSchema(Schema):
@@ -39,13 +40,11 @@ class ProgramContactSchema(Schema):
     contact_id = fields.Integer()
     program_id = fields.Integer(load_only=True)
     program = fields.Nested(ProgramSchema, dump_only=True)
-    responses = fields.Nested(ResponseSchema, many=True)
     card_id = fields.String()
     stage = fields.Integer()
     is_approved = fields.Boolean()
     is_active = fields.Boolean()
-    reviews = fields.Nested(ReviewSchema, many=True, dump_only=True,
-                            cascade='all, delete, delete-orphan')
+    reviews = fields.Nested(ReviewSchema, many=True, dump_only=True)
 
     class Meta:
         unknown = EXCLUDE

--- a/models/program_model.py
+++ b/models/program_model.py
@@ -23,7 +23,6 @@ class Program(db.Model):
 class ProgramSchema(Schema):
     id = fields.Integer(dump_only=True)
     name = fields.String(required=True)
-    questions = fields.Nested(QuestionSchema, many=True)
     current_cycle = fields.Nested(CycleSchema)
 
     class Meta:

--- a/resources/FormAssembly.py
+++ b/resources/FormAssembly.py
@@ -26,6 +26,10 @@ def get_review_talent_board_id(program_id):
     program = Program.query.get(program_id)
     return program.current_cycle.review_talent_board_id
 
+def get_current_cycle_id(program_id):
+    program = Program.query.get(program_id)
+    return program.current_cycle.id
+
 def find_opp_card(form_data):
     board_id = get_matching_opp_board_id(form_data['program_id'])
     board_data = query_board_data(board_id)
@@ -49,7 +53,9 @@ class OpportunityIntakeApp(Resource):
             'gdoc_id': gdoc_id,
             'card_id': opp_card.id,
             'stage': OpportunityStage.submitted.value,
-            'gdoc_link': gdoc_link
+            'gdoc_link': gdoc_link,
+            'org_name': form_data['org'],
+            'cycle_id': get_current_cycle_id(form_data['program_id'])
         }
         opp = create_new_opportunity(opp_data)
         opp_card.set_custom_field_values(**{'Opp ID': opp.id})

--- a/resources/FormAssembly.py
+++ b/resources/FormAssembly.py
@@ -41,12 +41,15 @@ class OpportunityIntakeApp(Resource):
         opp_card, board = find_opp_card(form_data)
         if opp_card is None:
             return {'message': 'No card found'}, 404
+        gdoc_id = form_data['google_doc_id']
+        gdoc_link = f'https://docs.google.com/document/d/{gdoc_id}/edit'
         opp_data = {
             'title': form_data['title'],
             'short_description': '',
-            'gdoc_id': form_data['google_doc_id'],
+            'gdoc_id': gdoc_id,
             'card_id': opp_card.id,
-            'stage': OpportunityStage.submitted.value
+            'stage': OpportunityStage.submitted.value,
+            'gdoc_link': gdoc_link
         }
         opp = create_new_opportunity(opp_data)
         opp_card.set_custom_field_values(**{'Opp ID': opp.id})

--- a/resources/Opportunity.py
+++ b/resources/Opportunity.py
@@ -3,12 +3,13 @@ import uuid
 
 from flask_restful import Resource, request
 from flask_login import login_required
-from flask import current_app 
+from flask import current_app
 
 from auth import refresh_session
 
 from models.base_model import db
 from models.opportunity_model import Opportunity, OpportunitySchema
+from marshmallow import ValidationError
 
 from auth import is_authorized_with_permission, unauthorized
 

--- a/resources/ProgramContacts.py
+++ b/resources/ProgramContacts.py
@@ -31,12 +31,9 @@ def create_program_contact(contact_id, program_id=1, **data):
     program_contact = query_one_program_contact(contact_id, program_id)
     if program_contact:
         return {'message': 'Record already exists'}, 400
-    responses = data.pop('responses', None)
     data['contact_id'] = contact_id
     data['program_id'] = program_id
     program_contact = ProgramContact(**data)
-    if responses:
-        add_responses(responses, program_contact)
     db.session.add(program_contact)
     db.session.commit()
     result = program_contact_schema.dump(program_contact)
@@ -110,15 +107,8 @@ class ProgramContactOne(Resource):
         if not program_contact:
             return {'message': 'Record does not exist'}, 404
 
-        # updates program_contact record and related response records
-        responses = data.pop('responses', None)
-        for k,v in data.items():
-            if k in UPDATE_FIELDS:
-                setattr(program_contact, k, v)
-        if responses:
-            del program_contact.responses[:]
-            add_responses(responses, program_contact)
-
+        # updates program_contact record
+        program_contact.update(**data)
         db.session.commit()
         result = program_contact_schema.dump(program_contact)
         return {"status": 'success', 'data': result}, 200

--- a/tests/populate_db.py
+++ b/tests/populate_db.py
@@ -28,8 +28,8 @@ from models.tag_model import (
 )
 from models.tag_item_model import TagItem
 from models.skill_model import (
-    Skill, 
-    Capability, 
+    Skill,
+    Capability,
     SkillRecommendation,
     CapabilitySkillSuggestion
 )
@@ -200,7 +200,7 @@ skills = [
     Skill(
         id=get_skill_id(name),
         name=name,
-    ) 
+    )
     for name in [
         'Python',
         'C++',
@@ -231,7 +231,7 @@ advocacy_recommendations = [
         capability_id='cap:advocacy',
         skill_id=get_skill_id(name),
         order=i
-    ) 
+    )
     for (i, name) in enumerate([
         'Community Organizing',
         'Canvassing',
@@ -249,7 +249,7 @@ outreach_recommendations = [
         capability_id='cap:outreach',
         skill_id=get_skill_id(name),
         order=i
-    ) 
+    )
     for (i, name) in enumerate([
         'Community Engagement',
         'Client Recruitment',
@@ -308,6 +308,7 @@ billy_pfp = ProgramContact(
     contact_id=123,
     card_id='card',
     stage=1,
+    is_approved=True
 )
 
 r_billy1 = Response(
@@ -338,7 +339,9 @@ test_opp1 = Opportunity(
     short_description="This is a test opportunity.",
     gdoc_id="ABC123xx==",
     card_id="card",
-    gdoc_link="https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit"
+    gdoc_link="https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit",
+    org_name="Test Org",
+    cycle_id=2,
 )
 
 test_opp2 = Opportunity(
@@ -347,7 +350,9 @@ test_opp2 = Opportunity(
     short_description="This is another test opportunity.",
     gdoc_id="BBB222xx==",
     card_id="card",
-    gdoc_link="https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit"
+    gdoc_link="https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit",
+    org_name="Test Org",
+    cycle_id=2,
 )
 
 app_billy = OpportunityApp(
@@ -448,4 +453,3 @@ def populate(db):
     db.session.add(it_capability)
 
     db.session.commit()
-

--- a/tests/populate_db.py
+++ b/tests/populate_db.py
@@ -338,6 +338,7 @@ test_opp1 = Opportunity(
     short_description="This is a test opportunity.",
     gdoc_id="ABC123xx==",
     card_id="card",
+    gdoc_link="https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit"
 )
 
 test_opp2 = Opportunity(
@@ -346,6 +347,7 @@ test_opp2 = Opportunity(
     short_description="This is another test opportunity.",
     gdoc_id="BBB222xx==",
     card_id="card",
+    gdoc_link="https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit"
 )
 
 app_billy = OpportunityApp(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -193,6 +193,7 @@ OPPORTUNITIES = {
         'title': "Test Opportunity",
         'short_description': "This is a test opportunity.",
         'gdoc_id': "ABC123xx==",
+        'gdoc_link': "https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit",
         'status': 'submitted',
     },
     'test_opp2': {
@@ -200,6 +201,7 @@ OPPORTUNITIES = {
         'title': "Another Test Opportunity",
         'short_description': "This is another test opportunity.",
         'gdoc_id': "BBB222xx==",
+        'gdoc_link': "https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit",
         'status': 'submitted',
     },
 
@@ -560,6 +562,7 @@ POSTS = {
         "title": "Test Opportunity",
         "short_description": "We are looking for a tester to test our application by taking this test opportunity. Testers of all experience welcome",
         "gdoc_id": "TESTABC11==",
+        "gdoc_link": "https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit"
     },
 }
 
@@ -615,10 +618,9 @@ def post_request(app, url, data):
       marks=pytest.mark.skip
       # TODO: unskip when trello stuff is mocked out
       )
-    ,pytest.param('/api/opportunity/',
+    ,('/api/opportunity/',
       POSTS['opportunity'],
-      lambda id: Opportunity.query.filter_by(title="Test Opportunity").first(),
-      marks=pytest.mark.skip
+      lambda id: Opportunity.query.filter_by(title="Test Opportunity").first()
       )
     ,pytest.param('/api/contacts/124/app/123abc/',
       {},


### PR DESCRIPTION
Merges the following branches into master:

- `opportunity-changes-for-ui`
- `contact-eligibility`
- `add-gdoc-link-to-opps`

Which does the following:

- Adds `gdoc_link`, `cycle_id`, and `org_name` to opportunity table
- Adds 'gdoc_link`, `cycle_id`, `org_name`, and `program_id` to opportunity schema
- Creates `contacts/<contact_id>/app/` which returns a list of applications associated with a given contact (used by the frontend to check the whether the contact has applied to the available opportunities)

Deployment considerations:

- **Heroku Variables:** N/A
- **DB Migrations:** Yes
- **Deployment sequence:** Backend before frontend
- **AuthZ/AuthN Changes:** N/A