### PR TITLE
Resume snapshot

### DIFF
--- a/models/opportunity_app_model.py
+++ b/models/opportunity_app_model.py
@@ -5,6 +5,7 @@ from marshmallow import Schema, fields, EXCLUDE
 from marshmallow_enum import EnumField
 from models.contact_model import ContactSchema
 from models.opportunity_model import OpportunitySchema
+from models.resume_model import ResumeSnapshotSchema
 
 class ApplicationStage(enum.Enum):
     draft = 0
@@ -17,9 +18,11 @@ class OpportunityApp(db.Model):
     id = db.Column(db.String, primary_key=True)
     contact_id = db.Column(db.Integer, db.ForeignKey('contact.id'), nullable=False)
     opportunity_id = db.Column(db.String, db.ForeignKey('opportunity.id'), nullable=False)
+    resume_id = db.Column(db.Integer, db.ForeignKey('resume_snapshot.id'), nullable=True)
     interest_statement = db.Column(db.String(2000), nullable=True)
     stage = db.Column(db.Integer, nullable=False, default=0)
 
+    resume = db.relationship('ResumeSnapshot')
     contact = db.relationship('Contact', back_populates='applications')
 
     opportunity = db.relationship('Opportunity')
@@ -40,6 +43,7 @@ class OpportunityAppSchema(Schema):
     contact = fields.Nested(ContactSchema, dump_only=True)
     opportunity = fields.Nested(OpportunitySchema, dump_only=True)
     interest_statement = fields.String()
+    resume = fields.Pluck(ResumeSnapshotSchema, field_name='resume')
     status = EnumField(ApplicationStage, dump_only=True)
 
     class Meta:

--- a/models/opportunity_app_model.py
+++ b/models/opportunity_app_model.py
@@ -43,7 +43,7 @@ class OpportunityAppSchema(Schema):
     contact = fields.Nested(ContactSchema, dump_only=True)
     opportunity = fields.Nested(OpportunitySchema, dump_only=True)
     interest_statement = fields.String()
-    resume = fields.Pluck(ResumeSnapshotSchema, field_name='resume')
+    resume = fields.Pluck(ResumeSnapshotSchema, field_name='resume', allow_none=True) 
     status = EnumField(ApplicationStage, dump_only=True)
 
     class Meta:

--- a/models/resume_model.py
+++ b/models/resume_model.py
@@ -1,5 +1,6 @@
+import json
 from models.base_model import db
-from marshmallow import Schema, fields, EXCLUDE
+from marshmallow import Schema, fields, EXCLUDE, pre_load, post_dump
 from models.resume_section_model import ResumeSection, ResumeSectionSchema
 from models.contact_model import ContactSchema
 from models.experience_model import ExperienceSchema
@@ -19,15 +20,10 @@ class Resume(db.Model):
     #sections = db.relationship('ResumeSection', back_populates='resume',
     #                           cascade='all, delete, delete-orphan')
 
-class ResumeSchema(Schema):
-    id = fields.Integer(dump_only=True)
-    contact_id = fields.Integer(required=True, load_only=True)
-    contact = fields.Nested(ContactSchema, dump_only=True)
-    name = fields.String(required=True)
-    date_created = fields.Date(required=True)
-    gdoc_id = fields.String(dump_only=True)
-    #sections = fields.Nested(ResumeSectionSchema, dump_only=True, many=True,
-    #                         exclude=['resume_id', 'contact_id'])
+class ResumeSnapshot(db.Model):
+    __tablename__ = 'resume_snapshot'
+    id = db.Column(db.Integer, primary_key=True)
+    resume = db.Column(db.Text, nullable=False)
 
 class ResumeSchemaNew(Schema):
     #fields used to load the data from the POST request
@@ -57,3 +53,31 @@ class ResumeSchemaNew(Schema):
 
     class Meta:
         unknown = EXCLUDE
+
+class ResumeSchema(Schema):
+    id = fields.Integer(dump_only=True)
+    contact_id = fields.Integer(required=True, load_only=True)
+    contact = fields.Nested(ContactSchema, dump_only=True)
+    name = fields.String(required=True)
+    date_created = fields.Date(required=True)
+    gdoc_id = fields.String(dump_only=True)
+    #sections = fields.Nested(ResumeSectionSchema, dump_only=True, many=True,
+    #                         exclude=['resume_id', 'contact_id'])
+
+class ResumeSnapshotSchema(Schema):
+    resume = fields.String(required=True)
+
+    @pre_load(pass_many=False)
+    def pack_json(self, data, many, **kwargs):
+        if 'resume' in data:
+            data['resume'] = json.dumps(data['resume'], separators=(',',':'))
+        return data
+
+    @post_dump(pass_many=False)
+    def unpack_json(self, data, many, **kwargs):
+        if 'resume' in data:
+            data['resume'] = json.loads(data['resume'])
+        return data
+
+
+

--- a/resources/Contacts.py
+++ b/resources/Contacts.py
@@ -52,6 +52,7 @@ class ContactAll(Resource):
             return unauthorized()
 
         contacts = Contact.query.all()
+
         contacts = contacts_schema.dump(contacts)
         return {'status': 'success', 'data': contacts}, 200
 

--- a/resources/OpportunityApp.py
+++ b/resources/OpportunityApp.py
@@ -86,7 +86,7 @@ class OpportunityAppOne(Resource):
         if not opportunity_app:
             return {'message': 'Application does not exist'}, 404
 
-        if 'resume' in data:
+        if data.get('resume') is not None:
             if opportunity_app.resume is None:
                 opportunity_app.resume = ResumeSnapshot(
                     **data['resume']

--- a/resources/OpportunityApp.py
+++ b/resources/OpportunityApp.py
@@ -3,6 +3,7 @@ import uuid
 
 from flask_restful import Resource, request
 from flask_login import login_required
+from marshmallow import ValidationError
 
 from models.base_model import db
 
@@ -12,7 +13,12 @@ from auth import (
     unauthorized, 
     refresh_session
 )
-from models.opportunity_app_model import OpportunityApp, OpportunityAppSchema, ApplicationStage
+from models.opportunity_app_model import (
+    OpportunityApp, 
+    OpportunityAppSchema, 
+    ApplicationStage
+)
+from models.resume_model import ResumeSnapshot
 
 opportunity_app_schema = OpportunityAppSchema()
 
@@ -79,6 +85,15 @@ class OpportunityAppOne(Resource):
 
         if not opportunity_app:
             return {'message': 'Application does not exist'}, 404
+
+        if 'resume' in data:
+            if opportunity_app.resume is None:
+                opportunity_app.resume = ResumeSnapshot(
+                    **data['resume']
+                )
+            else:
+                opportunity_app.resume.resume = data['resume']['resume']
+            del data['resume']
 
         for k,v in data.items():
             setattr(opportunity_app, k, v)

--- a/tests/populate_db.py
+++ b/tests/populate_db.py
@@ -41,6 +41,8 @@ from resources.skill_utils import get_skill_id, make_skill
 #from models.resume_section_model import ResumeSection
 #from models.resume_item_model import ResumeItem
 
+from models.resume_model import ResumeSnapshot
+
 # imports models related to the program and cycle
 from models.program_model import Program
 from models.program_contact_model import ProgramContact
@@ -348,12 +350,18 @@ test_opp2 = Opportunity(
     card_id="card",
 )
 
+snapshot1 = ResumeSnapshot(
+    id=1111,
+    resume='{"test":"snapshot1"}',
+)
+
 app_billy = OpportunityApp(
     id='a1',
     contact_id=123,
     opportunity_id='123abc',
     interest_statement="I'm interested in this test opportunity",
     stage=1,
+    resume_id=1111,
 )
 
 app_billy2 = OpportunityApp(
@@ -404,6 +412,7 @@ def populate(db):
     db.session.add(review_billy)
     db.session.add(test_opp1)
     db.session.add(test_opp2)
+    db.session.add(snapshot1)
     db.session.add(app_billy)
     db.session.add(app_billy2)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -268,6 +268,15 @@ CONTACTS = {
     },
 }
 
+SNAPSHOTS = {
+    'snapshot1': {
+        'test': 'snapshot1'
+    },
+    'snapshot2': {
+        'test': 'snapshot2'
+    },
+}
+
 APPLICATIONS = {
     'app_billy': {
         'id': 'a1',
@@ -275,6 +284,7 @@ APPLICATIONS = {
         'opportunity': OPPORTUNITIES['test_opp1'],
         'interest_statement': "I'm interested in this test opportunity",
         'status': 'submitted',
+        'resume': SNAPSHOTS['snapshot1'],
     },
     'app_billy2': {
         'id': 'a2',
@@ -920,6 +930,17 @@ def skill_name(skill):
       lambda: OpportunityApp.query.get('a1'),
       lambda r: r.interest_statement == 'New interest statement',
       )
+    ,('/api/contacts/123/app/123abc',
+      {'resume': {'test': 'snapshotnew'}},
+      lambda: OpportunityApp.query.get('a1'),
+      lambda r: r.resume.resume == '{"test":"snapshotnew"}',
+      )
+    ,('/api/contacts/123/app/222abc',
+      {'resume': {'test': 'snapshotnew'}},
+      lambda: OpportunityApp.query.get('a2'),
+      lambda r: r.resume and r.resume.resume == '{"test":"snapshotnew"}',
+      )
+
     ]
 )
 def test_put(app, url, update, query, test):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -926,7 +926,7 @@ def skill_name(skill):
       marks=pytest.mark.skip
       )
     ,('/api/contacts/123/app/123abc',
-      {'interest_statement': "New interest statement"},
+      {'interest_statement': "New interest statement", 'resume': None},
       lambda: OpportunityApp.query.get('a1'),
       lambda r: r.interest_statement == 'New interest statement',
       )


### PR DESCRIPTION
Merges `resume-snapshot` into `applicants-express-interest` feature set branch:

- Creates `resume_snapshot` table with `id` and `resume` columns, which stores a text serialized version of the json data needed to populate the resume in the frontend
- When updating the `opportunity_app` record, creates a step to check for resume data and if it exists, it creates a new `resume_snapshot` record and relates it to the `opportunity_app` record

Considerations for deployment: 

- **DB Migration:** Yes
- **Heroku Variables:** N/A
- **Deployment Sequence:**  Backend before frontend
- **AuthZ/N Changes:** N/A