### PR TITLE
Staff opportunity view

### DIFF
--- a/api.py
+++ b/api.py
@@ -20,7 +20,7 @@ from resources.Trello_Intake_Talent import (
     IntakeTalentCard,
     ReviewTalentCard
 )
-from resources.Opportunity import OpportunityAll, OpportunityOne
+from resources.Opportunity import OpportunityAll, OpportunityAllInternal, OpportunityOne
 from resources.OpportunityApp import OpportunityAppOne, OpportunityAppSubmit
 from resources.FormAssembly import (
     TalentProgramApp,
@@ -132,8 +132,9 @@ api.add_resource(Session,
 api.add_resource(OpportunityAll,
                  '/opportunity',
                  '/opportunity/')
+api.add_resource(OpportunityAllInternal,
+                 '/opportunity/app/',
+                 '/opportunity/app')
 api.add_resource(OpportunityOne,
                  '/opportunity/<string:opportunity_id>',
                  '/opportunity/<string:opportunity_id>/')
-
-

--- a/api.py
+++ b/api.py
@@ -8,8 +8,8 @@ from resources.Resume import ResumeAll, ResumeOne, GenerateResume
 from resources.Resume import ResumeSectionAll, ResumeSectionOne
 from resources.Skills import ContactSkills, ContactSkillOne, AutocompleteSkill
 from resources.Capability import (
-    CapabilityRecommended, 
-    ContactCapabilities, 
+    CapabilityRecommended,
+    ContactCapabilities,
     ContactCapabilitySuggestions,
     ContactCapabilitySuggestionOne,
 )
@@ -133,8 +133,8 @@ api.add_resource(OpportunityAll,
                  '/opportunity',
                  '/opportunity/')
 api.add_resource(OpportunityAllInternal,
-                 '/opportunity/app/',
-                 '/opportunity/app')
+                 '/internal/opportunities/',
+                 'internal/opportunities')
 api.add_resource(OpportunityOne,
                  '/opportunity/<string:opportunity_id>',
                  '/opportunity/<string:opportunity_id>/')

--- a/models/opportunity_app_model.py
+++ b/models/opportunity_app_model.py
@@ -4,7 +4,6 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from marshmallow import Schema, fields, EXCLUDE
 from marshmallow_enum import EnumField
 from models.contact_model import ContactSchema
-from models.opportunity_model import OpportunitySchema
 
 class ApplicationStage(enum.Enum):
     draft = 0
@@ -30,20 +29,6 @@ class OpportunityApp(db.Model):
         return ApplicationStage(self.stage)
 
     __table_args__ = (
-        db.Index('oppapp_contact_opportunity', 
+        db.Index('oppapp_contact_opportunity',
                  'contact_id', 'opportunity_id', unique=True),
     )
-
-
-class OpportunityAppSchema(Schema):
-    id = fields.String(dump_only=True)
-    contact = fields.Nested(ContactSchema, dump_only=True)
-    opportunity = fields.Nested(OpportunitySchema, dump_only=True)
-    interest_statement = fields.String()
-    status = EnumField(ApplicationStage, dump_only=True)
-
-    class Meta:
-        unknown = EXCLUDE
-
-
-

--- a/models/opportunity_app_model.py
+++ b/models/opportunity_app_model.py
@@ -9,6 +9,8 @@ class ApplicationStage(enum.Enum):
     draft = 0
     submitted = 1
 
+UPDATE_FIELDS = ['interest_statement', 'stage']
+
 class OpportunityApp(db.Model):
     __tablename__ = 'opportunity_app'
 
@@ -23,12 +25,21 @@ class OpportunityApp(db.Model):
 
     opportunity = db.relationship('Opportunity')
 
+    __table_args__ = (
+        db.Index('oppapp_contact_opportunity',
+                 'contact_id', 'opportunity_id', unique=True),
+    )
+
     #calculated fields
     @hybrid_property
     def status(self):
         return ApplicationStage(self.stage)
 
-    __table_args__ = (
-        db.Index('oppapp_contact_opportunity',
-                 'contact_id', 'opportunity_id', unique=True),
-    )
+    # for more info on why to use setattr() read this:
+    # https://medium.com/@s.azad4/modifying-python-objects-within-the-sqlalchemy-framework-7b6c8dd71ab3
+    def update(self, **update_dict):
+        for field, value in update_dict.items():
+            print(field, value)
+            if field in UPDATE_FIELDS:
+                setattr(self, field, value)
+        db.session.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ itsdangerous==1.1.0
 Jinja2>=2.10.1
 Mako==1.0.7
 MarkupSafe==1.1.0
-marshmallow==3.2.1
+marshmallow==3.5.0
 marshmallow-enum==1.5.1
 psycopg2>=2.8
 pytest==4.4.0

--- a/resources/Opportunity.py
+++ b/resources/Opportunity.py
@@ -8,7 +8,7 @@ from flask import current_app
 from auth import refresh_session
 
 from models.base_model import db
-from models.opportunity_model import Opportunity, OpportunitySchema
+from models.opportunity_model import Opportunity, OpportunitySchema, OpportunityAppSchema
 
 from auth import is_authorized_with_permission, unauthorized
 
@@ -22,8 +22,9 @@ def create_new_opportunity(opportunity_data):
     return opportunity
 
 
-opportunity_schema = OpportunitySchema()
-opportunities_schema = OpportunitySchema(many=True)
+opportunity_schema = OpportunitySchema(exclude=['applications'])
+opportunities_internal_schema = OpportunitySchema(many=True)
+opportunities_schema = OpportunitySchema(exclude=['applications'],many=True)
 class OpportunityAll(Resource):
     method_decorators = {
         'post': [login_required, refresh_session],
@@ -49,6 +50,14 @@ class OpportunityAll(Resource):
         opportunity = create_new_opportunity(data)
         result = opportunity_schema.dump(opportunity)
         return {"status": 'success', 'data': result}, 201
+
+class OpportunityAllInternal(Resource):
+
+    def get(self):
+        opportunities = Opportunity.query.all();
+        opp_list = opportunities_internal_schema.dump(opportunities)
+        return {'status': 'success', 'data': opp_list}, 200
+        return {'status': 'success', 'data': 'Hello World'}, 200
 
 class OpportunityOne(Resource):
     method_decorators = {

--- a/resources/Opportunity.py
+++ b/resources/Opportunity.py
@@ -52,9 +52,14 @@ class OpportunityAll(Resource):
         return {"status": 'success', 'data': result}, 201
 
 class OpportunityAllInternal(Resource):
+    method_decorators = {
+        'get': [login_required, refresh_session]
+    }
 
     def get(self):
         opportunities = Opportunity.query.all();
+        if not is_authorized_with_permission('view:opportunity-internal'):
+            return unauthorized()
         opp_list = opportunities_internal_schema.dump(opportunities)
         return {'status': 'success', 'data': opp_list}, 200
         return {'status': 'success', 'data': 'Hello World'}, 200

--- a/resources/OpportunityApp.py
+++ b/resources/OpportunityApp.py
@@ -12,7 +12,8 @@ from auth import (
     unauthorized, 
     refresh_session
 )
-from models.opportunity_app_model import OpportunityApp, OpportunityAppSchema, ApplicationStage
+from models.opportunity_app_model import OpportunityApp, ApplicationStage
+from models.opportunity_model import OpportunityAppSchema
 
 opportunity_app_schema = OpportunityAppSchema()
 

--- a/resources/OpportunityApp.py
+++ b/resources/OpportunityApp.py
@@ -81,13 +81,12 @@ class OpportunityAppOne(Resource):
         if not opportunity_app:
             return {'message': 'Application does not exist'}, 404
 
-        for k,v in data.items():
-            setattr(opportunity_app, k, v)
+        opportunity_app.update(**data)
 
         db.session.commit()
         result = opportunity_app_schema.dump(opportunity_app)
         return {'status': 'success', 'data': result}, 200
-        
+
 class OpportunityAppSubmit(Resource):
     method_decorators = {
         'post': [login_required, refresh_session],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -268,6 +268,32 @@ CONTACTS = {
     },
 }
 
+OPPORTUNITIES_INTERNAL = {
+    'test_opp1': {
+        'id': '123abc',
+        'title': "Test Opportunity",
+        'short_description': "This is a test opportunity.",
+        'gdoc_id': "ABC123xx==",
+        'status': 'submitted',
+        'applications': [{'id': 'a1',
+                         'contact': CONTACTS['billy'],
+                         'interest_statement': "I'm interested in this test opportunity",
+                         'status': 'submitted'}]
+    },
+    'test_opp2': {
+        'id': '222abc',
+        'title': "Another Test Opportunity",
+        'short_description': "This is another test opportunity.",
+        'gdoc_id': "BBB222xx==",
+        'status': 'submitted',
+        'applications': [{'id': 'a2',
+                          'contact': CONTACTS['billy'],
+                          'interest_statement': "I'm also interested in this test opportunity",
+                          'status': 'draft'}]
+    },
+
+}
+
 APPLICATIONS = {
     'app_billy': {
         'id': 'a1',
@@ -1253,6 +1279,7 @@ def test_get_capability_recommendations(app):
     ,('/api/contacts/123/achievements/', ACHIEVEMENTS.values())
     ,('/api/contacts/123/programs/', [PROGRAM_CONTACTS['billy_pfp']])
     ,('/api/opportunity/', OPPORTUNITIES.values())
+    ,('/api/opportunity/app/', OPPORTUNITIES_INTERNAL.values())
     ]
 )
 def test_get_many_unordered(app, url, expected):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1292,7 +1292,7 @@ def test_get_capability_recommendations(app):
     ,('/api/contacts/123/achievements/', ACHIEVEMENTS.values())
     ,('/api/contacts/123/programs/', [PROGRAM_CONTACTS['billy_pfp']])
     ,('/api/opportunity/', OPPORTUNITIES.values())
-    ,('/api/opportunity/app/', OPPORTUNITIES_INTERNAL.values())
+    ,('/api/internal/opportunities/', OPPORTUNITIES_INTERNAL.values())
     ]
 )
 def test_get_many_unordered(app, url, expected):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,8 +18,8 @@ from models.skill_model import (
     CapabilitySkillSuggestion
 )
 from models.skill_item_model import (
-    ContactSkill, 
-    ExperienceSkill, 
+    ContactSkill,
+    ExperienceSkill,
     AchievementSkill,
 )
 
@@ -589,6 +589,94 @@ POSTS = {
     },
 }
 
+APP_PUT_FULL = {
+    "opportunity": {
+      "gdoc_id": "1rnG47mblCVi1mDhB-UNRjs31zrmVaC8jYHvE2wXT4ws",
+      "cycle_id": 1,
+      "program_id": 1,
+      "title": "Web Developer",
+      "id": "94a6103c-c985-4db1-bd4e-e9e815c4cdda",
+      "org_name": "Test Org",
+      "short_description": "",
+      "status": "submitted"
+    },
+    "interest_statement": "dfdddsdfff",
+    "id": "052904ba-7b83-436c-aee3-334a208fefd9",
+    "contact": {
+      "birthdate": null,
+      "race_all": "Black or African Descent;Native Hawaiian or Other Pacific Islander",
+      "programs": [
+        {
+          "card_id": "card",
+          "program": {
+            "id": 1,
+            "current_cycle": {
+              "match_talent_board_id": "match_talent",
+              "is_active": true,
+              "date_start": "2020-01-01",
+              "review_talent_board_id": "5e39bb0daf879105b1c24462",
+              "match_opp_board_id": "5e4b203d1e7b0c48258fb268",
+              "program_id": 1,
+              "intake_org_board_id": "intake_org",
+              "date_end": "2020-03-30",
+              "id": 1,
+              "intake_talent_board_id": "5e25dae2e640be7e5248a3e6"
+            },
+            "name": "Place for Purpose"
+          },
+          "is_active": true,
+          "stage": 1,
+          "is_approved": false,
+          "id": 123,
+          "reviews": [
+
+          ],
+          "contact_id": 78
+        }
+      ],
+      "email_primary": {
+        "id": 465,
+        "type": "Personal",
+        "is_primary": true,
+        "email": "bayBC@baltimorecorps.org"
+      },
+      "last_name": "Bay BAY",
+      "pronouns": "She/Her",
+      "gender_other": null,
+      "race_other": null,
+      "phone_primary": "+1 (555) 555-9999",
+      "skills": [
+        {
+          "id": "FsleYWdpSaCA_qO3nkdMVw==",
+          "name": "Budgeting"
+        },
+        {
+          "id": "ZjcmI1kzC_Nm0MBejLPhDQ==",
+          "name": "Grant Writing"
+        },
+        {
+          "id": "-PmqNY7802oljpcsgL0ZLQ==",
+          "name": "Metrics"
+        }
+      ],
+      "account_id": "google-oauth2|105475713561673035322",
+      "pronouns_other": null,
+      "terms_agreement": true,
+      "id": 78,
+      "emails": [
+        {
+          "id": 465,
+          "type": "Personal",
+          "is_primary": true,
+          "email": "bayBC@baltimorecorps.org"
+        }
+      ],
+      "first_name": "New TEST",
+      "gender": "Non-Binary"
+    },
+    "status": "draft"
+  }
+
 def post_request(app, url, data):
     mimetype = 'application/json'
     headers = {
@@ -901,7 +989,7 @@ def skill_name(skill):
           'skills': [{'name': 'Python', 'capability_id': 'cap:it'}],
       }]},
       lambda: Experience.query.get(513),
-      lambda e: (len(e.achievements[-1].skills) == 1 
+      lambda e: (len(e.achievements[-1].skills) == 1
                  and e.achievements[-1].skills[0]['name'] == 'Python'
                  and e.achievements[-1].skills[0]['capability_id'] == 'cap:it'),
       )
@@ -912,7 +1000,7 @@ def skill_name(skill):
           'skills': [{'name': 'Recruitment', 'capability_id': 'cap:outreach'}],
       }]},
       lambda: Experience.query.get(513),
-      lambda e: (len(e.achievements[-1].skills) == 1 
+      lambda e: (len(e.achievements[-1].skills) == 1
                  and e.achievements[-1].skills[0]['name'] == 'Recruitment'
                  and e.achievements[-1].skills[0]['capability_id'] == 'cap:outreach'),
       )
@@ -920,7 +1008,7 @@ def skill_name(skill):
     ,('/api/experiences/513/',
       {'skills': SKILLS['billy'][0:2] + [{'name': 'Test'}]},
       lambda: Experience.query.get(513),
-      lambda e: (len(e.skills) == 3 
+      lambda e: (len(e.skills) == 3
                  and sorted(e.skills, key=skill_name)[0].name == 'Community Organizing'
                  and sorted(e.skills, key=skill_name)[1].name == 'Flask'
                  and sorted(e.skills, key=skill_name)[2].name == 'Test'),
@@ -946,6 +1034,11 @@ def skill_name(skill):
       lambda: OpportunityApp.query.get('a1'),
       lambda r: r.interest_statement == 'New interest statement',
       )
+     ,('/api/contacts/123/app/123abc',
+       {'interest_statement': "New interest statement"},
+       lambda: OpportunityApp.query.get('a1'),
+       lambda r: r.interest_statement == 'New interest statement',
+       )
     ]
 )
 def test_put(app, url, update, query, test):
@@ -1028,17 +1121,17 @@ def test_put_update_achievement_skills(app):
     }
     url = '/api/experiences/513/'
     update = {
-        'achievements': 
+        'achievements':
               EXPERIENCES['baltimore']['achievements'][0:2] + [{
                   'id': 83,
                   'description': 'Developed recruitment projection tools to model and track progress to goals.',
                   'skills': [{'name': 'Python', 'capability_id': 'cap:it'}],
               }],
         # Achievement skills should add to experience level skills
-        'skills': [], 
-    } 
+        'skills': [],
+    }
     query = lambda: Experience.query.get(513)
-    test = lambda e: (len(e.achievements[-1].skills) == 1 
+    test = lambda e: (len(e.achievements[-1].skills) == 1
                       and e.achievements[-1].skills[0]['name'] == 'Python')
     with app.test_client() as client:
         assert query() is not None, "Item to update should exist"
@@ -1260,7 +1353,7 @@ def test_get_capability_recommendations(app):
         'Information Technology': [],
     }
     with app.test_client() as client:
-        response = client.get('/api/capabilities/', 
+        response = client.get('/api/capabilities/',
                               headers=headers)
         assert response.status_code == 200
         data = json.loads(response.data)['data']

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -590,90 +590,10 @@ POSTS = {
 }
 
 APP_PUT_FULL = {
-    "opportunity": {
-      "gdoc_id": "1rnG47mblCVi1mDhB-UNRjs31zrmVaC8jYHvE2wXT4ws",
-      "cycle_id": 1,
-      "program_id": 1,
-      "title": "Web Developer",
-      "id": "94a6103c-c985-4db1-bd4e-e9e815c4cdda",
-      "org_name": "Test Org",
-      "short_description": "",
-      "status": "submitted"
-    },
+    "opportunity": OPPORTUNITIES['test_opp1'],
     "interest_statement": "dfdddsdfff",
     "id": "052904ba-7b83-436c-aee3-334a208fefd9",
-    "contact": {
-      "birthdate": null,
-      "race_all": "Black or African Descent;Native Hawaiian or Other Pacific Islander",
-      "programs": [
-        {
-          "card_id": "card",
-          "program": {
-            "id": 1,
-            "current_cycle": {
-              "match_talent_board_id": "match_talent",
-              "is_active": true,
-              "date_start": "2020-01-01",
-              "review_talent_board_id": "5e39bb0daf879105b1c24462",
-              "match_opp_board_id": "5e4b203d1e7b0c48258fb268",
-              "program_id": 1,
-              "intake_org_board_id": "intake_org",
-              "date_end": "2020-03-30",
-              "id": 1,
-              "intake_talent_board_id": "5e25dae2e640be7e5248a3e6"
-            },
-            "name": "Place for Purpose"
-          },
-          "is_active": true,
-          "stage": 1,
-          "is_approved": false,
-          "id": 123,
-          "reviews": [
-
-          ],
-          "contact_id": 78
-        }
-      ],
-      "email_primary": {
-        "id": 465,
-        "type": "Personal",
-        "is_primary": true,
-        "email": "bayBC@baltimorecorps.org"
-      },
-      "last_name": "Bay BAY",
-      "pronouns": "She/Her",
-      "gender_other": null,
-      "race_other": null,
-      "phone_primary": "+1 (555) 555-9999",
-      "skills": [
-        {
-          "id": "FsleYWdpSaCA_qO3nkdMVw==",
-          "name": "Budgeting"
-        },
-        {
-          "id": "ZjcmI1kzC_Nm0MBejLPhDQ==",
-          "name": "Grant Writing"
-        },
-        {
-          "id": "-PmqNY7802oljpcsgL0ZLQ==",
-          "name": "Metrics"
-        }
-      ],
-      "account_id": "google-oauth2|105475713561673035322",
-      "pronouns_other": null,
-      "terms_agreement": true,
-      "id": 78,
-      "emails": [
-        {
-          "id": 465,
-          "type": "Personal",
-          "is_primary": true,
-          "email": "bayBC@baltimorecorps.org"
-        }
-      ],
-      "first_name": "New TEST",
-      "gender": "Non-Binary"
-    },
+    "contact": CONTACTS['billy'],
     "status": "draft"
   }
 
@@ -1035,9 +955,9 @@ def skill_name(skill):
       lambda r: r.interest_statement == 'New interest statement',
       )
      ,('/api/contacts/123/app/123abc',
-       {'interest_statement': "New interest statement"},
+       APP_PUT_FULL,
        lambda: OpportunityApp.query.get('a1'),
-       lambda r: r.interest_statement == 'New interest statement',
+       lambda r: r.interest_statement == 'dfdddsdfff',
        )
     ]
 )


### PR DESCRIPTION
Merges the feature branch `staff-opportunity-view` into `staging-staff-recommend-applicants` which adds the following functionality:

- Creates a new endpoint `GET api/internal/opportunities/` which returns a list of opportunities and the applications associated with them

Deployment considerations:

- **Heroku Variables:** N/A
- **DB Migrations:** N/A
- **Deployment Sequence:** Backend before frontend
- **AuthZ/N Changes:** New permission `view:internal-opportunity`