### PR TITLE
Feature staff recommend app

### DIFF
--- a/api.py
+++ b/api.py
@@ -24,7 +24,8 @@ from resources.Opportunity import OpportunityAll, OpportunityOne
 from resources.OpportunityApp import (
     OpportunityAppAll,
     OpportunityAppOne,
-    OpportunityAppSubmit
+    OpportunityAppSubmit,
+    OpportunityAppRecommend,
 )
 from resources.FormAssembly import (
     TalentProgramApp,
@@ -116,7 +117,9 @@ api.add_resource(OpportunityAppSubmit,
 api.add_resource(OpportunityAppAll,
                  '/contacts/<int:contact_id>/app',
                  '/contacts/<int:contact_id>/app/')
-
+api.add_resource(OpportunityAppRecommend,
+                 '/contacts/<int:contact_id>/app/<string:opportunity_id>/recommend',
+                 '/contacts/<int:contact_id>/app/<string:opportunity_id>/recommend/')
 api.add_resource(IntakeTalentBoard,
                  '/programs/<int:program_id>/trello/intake-talent',
                  '/programs/<int:program_id>/trello/intake-talent/')

--- a/models/opportunity_app_model.py
+++ b/models/opportunity_app_model.py
@@ -10,6 +10,7 @@ from models.resume_model import ResumeSnapshotSchema
 class ApplicationStage(enum.Enum):
     draft = 0
     submitted = 1
+    recommended = 2
 
 class OpportunityApp(db.Model):
     __tablename__ = 'opportunity_app'

--- a/resources/OpportunityApp.py
+++ b/resources/OpportunityApp.py
@@ -11,11 +11,12 @@ from auth import (
     is_authorized_view,
     is_authorized_write,
     unauthorized,
-    refresh_session
+    refresh_session,
+    is_authorized_with_permission
 )
 from models.opportunity_app_model import (
-    OpportunityApp, 
-    OpportunityAppSchema, 
+    OpportunityApp,
+    OpportunityAppSchema,
     ApplicationStage
 )
 from models.resume_model import ResumeSnapshot

--- a/resources/OpportunityApp.py
+++ b/resources/OpportunityApp.py
@@ -142,3 +142,27 @@ class OpportunityAppSubmit(Resource):
         db.session.commit()
         result = opportunity_app_schema.dump(opportunity_app)
         return {'status': 'success', 'data': result}, 200
+
+class OpportunityAppRecommend(Resource):
+    method_decorators = {
+        'post': [login_required, refresh_session],
+    }
+
+    def post(self, contact_id, opportunity_id):
+
+        if not is_authorized_with_permission('write:app'):
+            return unauthorized()
+
+        opportunity_app = (OpportunityApp.query
+            .filter_by(contact_id=contact_id, opportunity_id=opportunity_id)
+            .first())
+
+        if not opportunity_app:
+            return {'message': 'Application does not exist'}, 404
+        if opportunity_app.stage >= ApplicationStage.recommended.value:
+            return {'message': 'Application is already recommended'}, 400
+
+        opportunity_app.stage = ApplicationStage.recommended.value
+        db.session.commit()
+        result = opportunity_app_schema.dump(opportunity_app)
+        return {'status': 'success', 'data': result}, 200

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1150,6 +1150,20 @@ def test_opportunity_app_submit(app):
         assert response.status_code == 200
         assert OpportunityApp.query.get('a2').stage == ApplicationStage.submitted.value
 
+def test_opportunity_app_recommend(app):
+    mimetype = 'application/json'
+    headers = {
+        'Content-Type': mimetype,
+        'Accept': mimetype
+    }
+    update = {}
+    with app.test_client() as client:
+        assert OpportunityApp.query.get('a1').stage == ApplicationStage.submitted.value
+        response = client.post('/api/contacts/123/app/123abc/recommend/',
+                              data=json.dumps(update),
+                              headers=headers)
+        assert response.status_code == 200
+        assert OpportunityApp.query.get('a1').stage == ApplicationStage.recommended.value
 
 @pytest.mark.parametrize(
     "delete_url,query",


### PR DESCRIPTION
Merges `feature-staff-recommend-app` to `staging-staff-recommend-applicants` adding the following functionality:

- Creates endpoint `POST api/contacts/<contact_id>/app/<opportunity_id>/recommend/` which changes the stage of the `opportunity_application` to "recommended"

Considerations for deployment: 

- **Heroku Variables:** N/A
- **DB Migrations:** N/A
- **Deployment Sequence:** Backend before frontend
- **AuthN/Z Changes:** New permission `write:app`