### PR TITLE
Feature staff reopen app

### DIFF
--- a/api.py
+++ b/api.py
@@ -24,7 +24,8 @@ from resources.Opportunity import OpportunityAll, OpportunityOne
 from resources.OpportunityApp import (
     OpportunityAppAll,
     OpportunityAppOne,
-    OpportunityAppSubmit
+    OpportunityAppSubmit,
+    OpportunityAppReopen
 )
 from resources.FormAssembly import (
     TalentProgramApp,
@@ -116,7 +117,9 @@ api.add_resource(OpportunityAppSubmit,
 api.add_resource(OpportunityAppAll,
                  '/contacts/<int:contact_id>/app',
                  '/contacts/<int:contact_id>/app/')
-
+api.add_resource(OpportunityAppReopen,
+                 '/contacts/<int:contact_id>/app/<string:opportunity_id>/reopen',
+                 '/contacts/<int:contact_id>/app/<string:opportunity_id>/reopen/')
 api.add_resource(IntakeTalentBoard,
                  '/programs/<int:program_id>/trello/intake-talent',
                  '/programs/<int:program_id>/trello/intake-talent/')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1150,7 +1150,7 @@ def test_opportunity_app_submit(app):
         assert response.status_code == 200
         assert OpportunityApp.query.get('a2').stage == ApplicationStage.submitted.value
 
-def test_opportunity_app_submit(app):
+def test_opportunity_app_reopen(app):
     mimetype = 'application/json'
     headers = {
         'Content-Type': mimetype,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1150,6 +1150,21 @@ def test_opportunity_app_submit(app):
         assert response.status_code == 200
         assert OpportunityApp.query.get('a2').stage == ApplicationStage.submitted.value
 
+def test_opportunity_app_submit(app):
+    mimetype = 'application/json'
+    headers = {
+        'Content-Type': mimetype,
+        'Accept': mimetype
+    }
+    update = {}
+    with app.test_client() as client:
+        assert OpportunityApp.query.get('a1').stage == ApplicationStage.submitted.value
+        response = client.post('/api/contacts/123/app/123abc/reopen/',
+                              data=json.dumps(update),
+                              headers=headers)
+        assert response.status_code == 200
+        assert OpportunityApp.query.get('a1').stage == ApplicationStage.draft.value
+
 
 @pytest.mark.parametrize(
     "delete_url,query",


### PR DESCRIPTION
Merges `feature-staff-reopen-app` to `dev` adding the following functionality:

- Creates endpoint `POST api/contacts/<contact_id>/app/<opportunity_id>/reopen/` which changes the stage of the `opportunity_application` back to "draft"

Considerations for deployment: 

- **Heroku Variables:** N/A
- **DB Migrations:** N/A
- **Deployment Sequence:** Backend before frontend
- **AuthN/Z Changes:** New permission `write:app`