### PR TITLE
Staging staff recommend applicants

### DIFF
--- a/api.py
+++ b/api.py
@@ -26,6 +26,7 @@ from resources.OpportunityApp import (
     OpportunityAppOne,
     OpportunityAppSubmit,
     OpportunityAppRecommend,
+    OpportunityAppReopen
 )
 from resources.FormAssembly import (
     TalentProgramApp,
@@ -120,6 +121,9 @@ api.add_resource(OpportunityAppAll,
 api.add_resource(OpportunityAppRecommend,
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>/recommend',
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>/recommend/')
+api.add_resource(OpportunityAppReopen,
+                 '/contacts/<int:contact_id>/app/<string:opportunity_id>/reopen',
+                 '/contacts/<int:contact_id>/app/<string:opportunity_id>/reopen/')
 api.add_resource(IntakeTalentBoard,
                  '/programs/<int:program_id>/trello/intake-talent',
                  '/programs/<int:program_id>/trello/intake-talent/')

--- a/api.py
+++ b/api.py
@@ -20,7 +20,7 @@ from resources.Trello_Intake_Talent import (
     IntakeTalentCard,
     ReviewTalentCard
 )
-from resources.Opportunity import OpportunityAll, OpportunityOne
+from resources.Opportunity import OpportunityAll, OpportunityAllInternal, OpportunityOne
 from resources.OpportunityApp import (
     OpportunityAppAll,
     OpportunityAppOne,
@@ -145,6 +145,9 @@ api.add_resource(Session,
 api.add_resource(OpportunityAll,
                  '/opportunity',
                  '/opportunity/')
+api.add_resource(OpportunityAllInternal,
+                 '/internal/opportunities/',
+                 'internal/opportunities')
 api.add_resource(OpportunityOne,
                  '/opportunity/<string:opportunity_id>',
                  '/opportunity/<string:opportunity_id>/')

--- a/api.py
+++ b/api.py
@@ -24,7 +24,8 @@ from resources.Opportunity import OpportunityAll, OpportunityOne
 from resources.OpportunityApp import (
     OpportunityAppAll,
     OpportunityAppOne,
-    OpportunityAppSubmit
+    OpportunityAppSubmit,
+    OpportunityAppRecommend,
 )
 from resources.FormAssembly import (
     TalentProgramApp,
@@ -116,7 +117,9 @@ api.add_resource(OpportunityAppSubmit,
 api.add_resource(OpportunityAppAll,
                  '/contacts/<int:contact_id>/app',
                  '/contacts/<int:contact_id>/app/')
-
+api.add_resource(OpportunityAppRecommend,
+                 '/contacts/<int:contact_id>/app/<string:opportunity_id>/recommend',
+                 '/contacts/<int:contact_id>/app/<string:opportunity_id>/recommend/')
 api.add_resource(IntakeTalentBoard,
                  '/programs/<int:program_id>/trello/intake-talent',
                  '/programs/<int:program_id>/trello/intake-talent/')

--- a/api.py
+++ b/api.py
@@ -22,6 +22,7 @@ from resources.Trello_Intake_Talent import (
 )
 from resources.Opportunity import OpportunityAll, OpportunityAllInternal, OpportunityOne
 from resources.OpportunityApp import (
+    OpportunityAppReject,
     OpportunityAppAll,
     OpportunityAppOne,
     OpportunityAppSubmit,
@@ -115,6 +116,9 @@ api.add_resource(OpportunityAppOne,
 api.add_resource(OpportunityAppSubmit,
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>/submit',
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>/submit/')
+api.add_resource(OpportunityAppReject,
+                 '/contacts/<int:contact_id>/app/<string:opportunity_id>/not-a-fit',
+                 '/contacts/<int:contact_id>/app/<string:opportunity_id>/not-a-fit/')
 api.add_resource(OpportunityAppAll,
                  '/contacts/<int:contact_id>/app',
                  '/contacts/<int:contact_id>/app/')

--- a/models/opportunity_app_model.py
+++ b/models/opportunity_app_model.py
@@ -10,6 +10,7 @@ from models.resume_model import ResumeSnapshotSchema
 class ApplicationStage(enum.Enum):
     draft = 0
     submitted = 1
+    recommended = 2
 
 class OpportunityApp(db.Model):
     __tablename__ = 'opportunity_app'

--- a/models/opportunity_app_model.py
+++ b/models/opportunity_app_model.py
@@ -22,6 +22,7 @@ class OpportunityApp(db.Model):
     resume_id = db.Column(db.Integer, db.ForeignKey('resume_snapshot.id'), nullable=True)
     interest_statement = db.Column(db.String(2000), nullable=True)
     stage = db.Column(db.Integer, nullable=False, default=0)
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
 
     resume = db.relationship('ResumeSnapshot')
     contact = db.relationship('Contact', back_populates='applications')

--- a/models/opportunity_app_model.py
+++ b/models/opportunity_app_model.py
@@ -4,13 +4,13 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from marshmallow import Schema, fields, EXCLUDE
 from marshmallow_enum import EnumField
 from models.contact_model import ContactSchema
-from models.opportunity_model import OpportunitySchema
-from models.resume_model import ResumeSnapshotSchema
 
 class ApplicationStage(enum.Enum):
     draft = 0
     submitted = 1
     recommended = 2
+
+UPDATE_FIELDS = ['interest_statement', 'stage']
 
 class OpportunityApp(db.Model):
     __tablename__ = 'opportunity_app'
@@ -28,27 +28,22 @@ class OpportunityApp(db.Model):
 
     opportunity = db.relationship('Opportunity')
 
+    __table_args__ = (
+        db.Index('oppapp_contact_opportunity',
+                 'contact_id', 'opportunity_id', unique=True),
+    )
+
     #calculated fields
     @hybrid_property
     def status(self):
         return ApplicationStage(self.stage)
 
-    __table_args__ = (
-        db.Index('oppapp_contact_opportunity', 
-                 'contact_id', 'opportunity_id', unique=True),
-    )
 
-
-class OpportunityAppSchema(Schema):
-    id = fields.String(dump_only=True)
-    contact = fields.Nested(ContactSchema, dump_only=True)
-    opportunity = fields.Nested(OpportunitySchema, dump_only=True)
-    interest_statement = fields.String()
-    resume = fields.Pluck(ResumeSnapshotSchema, field_name='resume', allow_none=True) 
-    status = EnumField(ApplicationStage, dump_only=True)
-
-    class Meta:
-        unknown = EXCLUDE
-
-
-
+    # for more info on why to use setattr() read this:
+    # https://medium.com/@s.azad4/modifying-python-objects-within-the-sqlalchemy-framework-7b6c8dd71ab3
+    def update(self, **update_dict):
+        for field, value in update_dict.items():
+            print(field, value)
+            if field in UPDATE_FIELDS:
+                setattr(self, field, value)
+        db.session.commit()

--- a/models/opportunity_model.py
+++ b/models/opportunity_model.py
@@ -47,6 +47,7 @@ class OpportunityAppSchema(Schema):
     opportunity = fields.Nested(lambda: OpportunitySchema(exclude=('applications',)))
     interest_statement = fields.String()
     status = EnumField(ApplicationStage, dump_only=True)
+    is_active = fields.Boolean(dump_only=True)
     resume = fields.Pluck(ResumeSnapshotSchema, field_name='resume', allow_none=True)
 
     class Meta:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ itsdangerous==1.1.0
 Jinja2>=2.10.1
 Mako==1.0.7
 MarkupSafe==1.1.0
-marshmallow==3.2.1
+marshmallow==3.5.0
 marshmallow-enum==1.5.1
 psycopg2>=2.8
 pytest==4.4.0

--- a/resources/Opportunity.py
+++ b/resources/Opportunity.py
@@ -8,7 +8,7 @@ from flask import current_app
 from auth import refresh_session
 
 from models.base_model import db
-from models.opportunity_model import Opportunity, OpportunitySchema
+from models.opportunity_model import Opportunity, OpportunitySchema, OpportunityAppSchema
 from marshmallow import ValidationError
 
 from auth import is_authorized_with_permission, unauthorized
@@ -23,8 +23,9 @@ def create_new_opportunity(opportunity_data):
     return opportunity
 
 
-opportunity_schema = OpportunitySchema()
-opportunities_schema = OpportunitySchema(many=True)
+opportunity_schema = OpportunitySchema(exclude=['applications'])
+opportunities_internal_schema = OpportunitySchema(many=True)
+opportunities_schema = OpportunitySchema(exclude=['applications'],many=True)
 class OpportunityAll(Resource):
     method_decorators = {
         'post': [login_required, refresh_session],
@@ -50,6 +51,19 @@ class OpportunityAll(Resource):
         opportunity = create_new_opportunity(data)
         result = opportunity_schema.dump(opportunity)
         return {"status": 'success', 'data': result}, 201
+
+class OpportunityAllInternal(Resource):
+    method_decorators = {
+        'get': [login_required, refresh_session]
+    }
+
+    def get(self):
+        opportunities = Opportunity.query.all();
+        if not is_authorized_with_permission('view:opportunity-internal'):
+            return unauthorized()
+        opp_list = opportunities_internal_schema.dump(opportunities)
+        return {'status': 'success', 'data': opp_list}, 200
+        return {'status': 'success', 'data': 'Hello World'}, 200
 
 class OpportunityOne(Resource):
     method_decorators = {

--- a/resources/OpportunityApp.py
+++ b/resources/OpportunityApp.py
@@ -33,8 +33,6 @@ class OpportunityAppAll(Resource):
             .filter(OpportunityApp.contact_id==contact_id,
                     OpportunityApp.stage>=ApplicationStage.submitted.value)
             .all())
-        if not opportunity_apps:
-            return {'message': 'No applications found'}, 404
         data = opportunity_app_schema_many.dump(opportunity_apps)
         return {'status': 'success', 'data': data}, 200
 

--- a/resources/OpportunityApp.py
+++ b/resources/OpportunityApp.py
@@ -121,6 +121,30 @@ class OpportunityAppOne(Resource):
         result = opportunity_app_schema.dump(opportunity_app)
         return {'status': 'success', 'data': result}, 200
 
+class OpportunityAppReopen(Resource):
+    method_decorators = {
+        'post': [login_required, refresh_session],
+    }
+
+    def post(self, contact_id, opportunity_id):
+        if not is_authorized_with_permission("write:app"):
+            return unauthorized()
+
+        opportunity_app = (OpportunityApp.query
+            .filter_by(contact_id=contact_id, opportunity_id=opportunity_id)
+            .first())
+
+        if not opportunity_app:
+            return {'message': 'Application does not exist'}, 404
+        if opportunity_app.stage == ApplicationStage.draft.value:
+            return {'message': 'Application is already open for editing'}, 400
+
+        opportunity_app.stage = ApplicationStage.draft.value
+        db.session.commit()
+        result = opportunity_app_schema.dump(opportunity_app)
+        return {'status': 'success', 'data': result}, 200
+
+
 class OpportunityAppSubmit(Resource):
     method_decorators = {
         'post': [login_required, refresh_session],

--- a/resources/OpportunityApp.py
+++ b/resources/OpportunityApp.py
@@ -14,11 +14,8 @@ from auth import (
     refresh_session,
     is_authorized_with_permission
 )
-from models.opportunity_app_model import (
-    OpportunityApp,
-    OpportunityAppSchema,
-    ApplicationStage
-)
+from models.opportunity_app_model import OpportunityApp, ApplicationStage
+from models.opportunity_model import OpportunityAppSchema
 from models.resume_model import ResumeSnapshot
 
 opportunity_app_schema = OpportunityAppSchema()
@@ -114,8 +111,7 @@ class OpportunityAppOne(Resource):
                 opportunity_app.resume.resume = data['resume']['resume']
             del data['resume']
 
-        for k,v in data.items():
-            setattr(opportunity_app, k, v)
+        opportunity_app.update(**data)
 
         db.session.commit()
         result = opportunity_app_schema.dump(opportunity_app)

--- a/resources/OpportunityApp.py
+++ b/resources/OpportunityApp.py
@@ -185,3 +185,24 @@ class OpportunityAppRecommend(Resource):
         db.session.commit()
         result = opportunity_app_schema.dump(opportunity_app)
         return {'status': 'success', 'data': result}, 200
+
+class OpportunityAppReject(Resource):
+    method_decorators = {
+        'post': [login_required, refresh_session],
+    }
+
+    def post(self, contact_id, opportunity_id):
+
+        opportunity_app = (OpportunityApp.query
+            .filter_by(contact_id=contact_id, opportunity_id=opportunity_id)
+            .first())
+
+        if not opportunity_app:
+            return {'message': 'Application does not exist'}, 404
+        if opportunity_app.is_active == False:
+            return {'message': 'Application is already marked "Not a Fit"'}, 400
+
+        opportunity_app.is_active = False
+        db.session.commit()
+        result = opportunity_app_schema.dump(opportunity_app)
+        return {'status': 'success', 'data': result}, 200

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -315,7 +315,8 @@ OPPORTUNITIES_INTERNAL = {
         'applications': [{'id': 'a2',
                           'contact': CONTACTS['billy'],
                           'interest_statement': "I'm also interested in this test opportunity",
-                          'status': 'draft'}]
+                          'status': 'draft',
+                          'resume': None}]
     },
 }
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1164,6 +1164,22 @@ def test_opportunity_app_recommend(app):
                               headers=headers)
         assert response.status_code == 200
         assert OpportunityApp.query.get('a1').stage == ApplicationStage.recommended.value
+        
+def test_opportunity_app_reopen(app):
+    mimetype = 'application/json'
+    headers = {
+        'Content-Type': mimetype,
+        'Accept': mimetype
+    }
+    update = {}
+    with app.test_client() as client:
+        assert OpportunityApp.query.get('a1').stage == ApplicationStage.submitted.value
+        response = client.post('/api/contacts/123/app/123abc/reopen/',
+                              data=json.dumps(update),
+                              headers=headers)
+        assert response.status_code == 200
+        assert OpportunityApp.query.get('a1').stage == ApplicationStage.draft.value
+
 
 @pytest.mark.parametrize(
     "delete_url,query",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -301,6 +301,7 @@ OPPORTUNITIES_INTERNAL = {
                          'contact': CONTACTS['billy'],
                          'interest_statement': "I'm interested in this test opportunity",
                          'status': 'submitted',
+                         'is_active': True,
                          'resume': SNAPSHOTS['snapshot1']}]
     },
     'test_opp2': {
@@ -316,6 +317,7 @@ OPPORTUNITIES_INTERNAL = {
                           'contact': CONTACTS['billy'],
                           'interest_statement': "I'm also interested in this test opportunity",
                           'status': 'draft',
+                          'is_active': True,
                           'resume': None}]
     },
 }
@@ -328,6 +330,7 @@ APPLICATIONS = {
         'interest_statement': "I'm interested in this test opportunity",
         'status': 'submitted',
         'resume': SNAPSHOTS['snapshot1'],
+        'is_active': True,
     },
     'app_billy2': {
         'id': 'a2',
@@ -335,6 +338,7 @@ APPLICATIONS = {
         'opportunity': OPPORTUNITIES['test_opp2'],
         'interest_statement': "I'm also interested in this test opportunity",
         'status': 'draft',
+        'is_active': True,
     },
 
 }
@@ -1179,6 +1183,21 @@ def test_put_rejects_app_stage_update(app):
                               data=json.dumps(update),
                               headers=headers)
         assert OpportunityApp.query.get('a1').stage == ApplicationStage.submitted.value
+
+def test_opportunity_app_not_a_fit(app):
+    mimetype = 'application/json'
+    headers = {
+        'Content-Type': mimetype,
+        'Accept': mimetype
+    }
+    update = {}
+    with app.test_client() as client:
+        assert OpportunityApp.query.get('a1').is_active == True
+        response = client.post('/api/contacts/123/app/123abc/not-a-fit/',
+                              data=json.dumps(update),
+                              headers=headers)
+        assert response.status_code == 200
+        assert OpportunityApp.query.get('a1').is_active == False
 
 def test_opportunity_app_submit(app):
     mimetype = 'application/json'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1401,6 +1401,21 @@ def test_get_contact_capabilities(app):
         pprint(data)
         assert data == expected
 
+def test_get_contact_without_apps(app):
+    mimetype = 'application/json'
+    headers = {
+        'Content-Type': mimetype,
+        'Accept': mimetype
+    }
+    url, expected = ('/api/contacts/124/app/', [])
+    with app.test_client() as client:
+        response = client.get(url, headers=headers)
+        assert response.status_code == 200
+        data = json.loads(response.data)['data']
+
+        pprint(expected)
+        pprint(data)
+        assert data == expected
 
 @pytest.mark.skip
 @pytest.mark.parametrize(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -287,6 +287,38 @@ SNAPSHOTS = {
     },
 }
 
+OPPORTUNITIES_INTERNAL = {
+    'test_opp1': {
+        'id': '123abc',
+        'title': "Test Opportunity",
+        'short_description': "This is a test opportunity.",
+        'gdoc_link': "https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit",
+        'status': 'submitted',
+        'org_name': 'Test Org',
+        'cycle_id': 2,
+        'program_id': 1,
+        'applications': [{'id': 'a1',
+                         'contact': CONTACTS['billy'],
+                         'interest_statement': "I'm interested in this test opportunity",
+                         'status': 'submitted',
+                         'resume': SNAPSHOTS['snapshot1']}]
+    },
+    'test_opp2': {
+        'id': '222abc',
+        'title': "Another Test Opportunity",
+        'short_description': "This is another test opportunity.",
+        'gdoc_link': "https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit",
+        'status': 'submitted',
+        'org_name': 'Test Org',
+        'cycle_id': 2,
+        'program_id': 1,
+        'applications': [{'id': 'a2',
+                          'contact': CONTACTS['billy'],
+                          'interest_statement': "I'm also interested in this test opportunity",
+                          'status': 'draft'}]
+    },
+}
+
 APPLICATIONS = {
     'app_billy': {
         'id': 'a1',
@@ -585,6 +617,14 @@ POSTS = {
         "gdoc_link": "https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit"
     },
 }
+
+APP_PUT_FULL = {
+    "opportunity": OPPORTUNITIES['test_opp1'],
+    "interest_statement": "dfdddsdfff",
+    "id": "052904ba-7b83-436c-aee3-334a208fefd9",
+    "contact": CONTACTS['billy'],
+    "status": "draft"
+  }
 
 def post_request(app, url, data):
     mimetype = 'application/json'
@@ -953,7 +993,11 @@ def skill_name(skill):
       lambda: OpportunityApp.query.get('a2'),
       lambda r: r.resume and r.resume.resume == '{"test":"snapshotnew"}',
       )
-
+     ,('/api/contacts/123/app/123abc',
+       APP_PUT_FULL,
+       lambda: OpportunityApp.query.get('a1'),
+       lambda r: r.interest_statement == 'dfdddsdfff',
+       )
     ]
 )
 def test_put(app, url, update, query, test):
@@ -1164,7 +1208,7 @@ def test_opportunity_app_recommend(app):
                               headers=headers)
         assert response.status_code == 200
         assert OpportunityApp.query.get('a1').stage == ApplicationStage.recommended.value
-        
+
 def test_opportunity_app_reopen(app):
     mimetype = 'application/json'
     headers = {
@@ -1318,6 +1362,7 @@ def test_get_capability_recommendations(app):
     ,('/api/contacts/123/programs/', [PROGRAM_CONTACTS['billy_pfp']])
     ,('/api/opportunity/', OPPORTUNITIES.values())
     ,('/api/contacts/123/app/', [APPLICATIONS['app_billy']])
+    ,('/api/internal/opportunities/', OPPORTUNITIES_INTERNAL.values())
     ]
 )
 def test_get_many_unordered(app, url, expected):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1150,6 +1150,20 @@ def test_opportunity_app_submit(app):
         assert response.status_code == 200
         assert OpportunityApp.query.get('a2').stage == ApplicationStage.submitted.value
 
+def test_opportunity_app_recommend(app):
+    mimetype = 'application/json'
+    headers = {
+        'Content-Type': mimetype,
+        'Accept': mimetype
+    }
+    update = {}
+    with app.test_client() as client:
+        assert OpportunityApp.query.get('a1').stage == ApplicationStage.submitted.value
+        response = client.post('/api/contacts/123/app/123abc/recommend/',
+                              data=json.dumps(update),
+                              headers=headers)
+        assert response.status_code == 200
+        assert OpportunityApp.query.get('a1').stage == ApplicationStage.recommended.value
 
 @pytest.mark.parametrize(
     "delete_url,query",


### PR DESCRIPTION
Changes:

- Creates endpoint `GET api/internal/opportunities/` which returns a list of opportunities and their related applications
- Creates endpoint `POST api/contacts/<contact_id>/app/<opp_id>/recommend/` which sets the status of the opportunity app record to 'recommended'
- Creates endpoint `POST api/contacts/<contact_id>/app/<opp_id>/reopen/` which resets the status of the opportunity app record to 'draft'
- Creates endpoint `POST api/contacts/<contact_id>/app/<opp_id>/not-a-fit/` which sets `is_active=false` on the opportunity app record
- Fixes the bug with the status code when calling `GET api/contacts/<contact_id>/app/`

Considerations for deployment:

- **Heroku Variables:** N/A
- **DB Migrations:** Yes
- **AuthZ/N Changes:** create new permission `write:app`
- **Deployment Sequence:** Backend before frontend