### PR TITLE
Feature staff reject app

### DIFF
--- a/api.py
+++ b/api.py
@@ -22,6 +22,7 @@ from resources.Trello_Intake_Talent import (
 )
 from resources.Opportunity import OpportunityAll, OpportunityOne
 from resources.OpportunityApp import (
+    OpportunityAppReject,
     OpportunityAppAll,
     OpportunityAppOne,
     OpportunityAppSubmit
@@ -113,6 +114,9 @@ api.add_resource(OpportunityAppOne,
 api.add_resource(OpportunityAppSubmit,
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>/submit',
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>/submit/')
+api.add_resource(OpportunityAppReject,
+                 '/contacts/<int:contact_id>/app/<string:opportunity_id>/not-a-fit',
+                 '/contacts/<int:contact_id>/app/<string:opportunity_id>/not-a-fit/')
 api.add_resource(OpportunityAppAll,
                  '/contacts/<int:contact_id>/app',
                  '/contacts/<int:contact_id>/app/')

--- a/models/opportunity_app_model.py
+++ b/models/opportunity_app_model.py
@@ -21,6 +21,7 @@ class OpportunityApp(db.Model):
     resume_id = db.Column(db.Integer, db.ForeignKey('resume_snapshot.id'), nullable=True)
     interest_statement = db.Column(db.String(2000), nullable=True)
     stage = db.Column(db.Integer, nullable=False, default=0)
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
 
     resume = db.relationship('ResumeSnapshot')
     contact = db.relationship('Contact', back_populates='applications')
@@ -45,6 +46,7 @@ class OpportunityAppSchema(Schema):
     interest_statement = fields.String()
     resume = fields.Pluck(ResumeSnapshotSchema, field_name='resume', allow_none=True) 
     status = EnumField(ApplicationStage, dump_only=True)
+    is_active = fields.Boolean(dump_only=True)
 
     class Meta:
         unknown = EXCLUDE

--- a/resources/OpportunityApp.py
+++ b/resources/OpportunityApp.py
@@ -14,8 +14,8 @@ from auth import (
     refresh_session
 )
 from models.opportunity_app_model import (
-    OpportunityApp, 
-    OpportunityAppSchema, 
+    OpportunityApp,
+    OpportunityAppSchema,
     ApplicationStage
 )
 from models.resume_model import ResumeSnapshot
@@ -139,6 +139,29 @@ class OpportunityAppSubmit(Resource):
             return {'message': 'Application is already submitted'}, 400
 
         opportunity_app.stage = ApplicationStage.submitted.value
+        db.session.commit()
+        result = opportunity_app_schema.dump(opportunity_app)
+        return {'status': 'success', 'data': result}, 200
+
+
+
+class OpportunityAppReject(Resource):
+    method_decorators = {
+        'post': [login_required, refresh_session],
+    }
+
+    def post(self, contact_id, opportunity_id):
+
+        opportunity_app = (OpportunityApp.query
+            .filter_by(contact_id=contact_id, opportunity_id=opportunity_id)
+            .first())
+
+        if not opportunity_app:
+            return {'message': 'Application does not exist'}, 404
+        if opportunity_app.is_active == False:
+            return {'message': 'Application is already marked "Not a Fit"'}, 400
+
+        opportunity_app.is_active = False
         db.session.commit()
         result = opportunity_app_schema.dump(opportunity_app)
         return {'status': 'success', 'data': result}, 200

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -295,6 +295,7 @@ APPLICATIONS = {
         'interest_statement': "I'm interested in this test opportunity",
         'status': 'submitted',
         'resume': SNAPSHOTS['snapshot1'],
+        'is_active': True,
     },
     'app_billy2': {
         'id': 'a2',
@@ -302,6 +303,7 @@ APPLICATIONS = {
         'opportunity': OPPORTUNITIES['test_opp2'],
         'interest_statement': "I'm also interested in this test opportunity",
         'status': 'draft',
+        'is_active': True,
     },
 
 }
@@ -1134,6 +1136,21 @@ def test_put_rejects_app_stage_update(app):
                               data=json.dumps(update),
                               headers=headers)
         assert OpportunityApp.query.get('a1').stage == ApplicationStage.submitted.value
+
+def test_opportunity_app_not_a_fit(app):
+    mimetype = 'application/json'
+    headers = {
+        'Content-Type': mimetype,
+        'Accept': mimetype
+    }
+    update = {}
+    with app.test_client() as client:
+        assert OpportunityApp.query.get('a1').is_active == True
+        response = client.post('/api/contacts/123/app/123abc/not-a-fit/',
+                              data=json.dumps(update),
+                              headers=headers)
+        assert response.status_code == 200
+        assert OpportunityApp.query.get('a1').is_active == False
 
 def test_opportunity_app_submit(app):
     mimetype = 'application/json'


### PR DESCRIPTION
Creates endpoint `POST api/contacts/<contact_id>/app/<opp_id>/not-a-fit/` which sets the `is_active` field on the opportunity_app record to `false`

Deployment Considerations

- **Heroku Variables:** N/A
- **DB Migrations:** Yes
- **AuthZ/N Changes:** new staff permission `write:app`
- **Deployment Sequence:** Backend before frontend