### PR TITLE
Feature program contact approve

### DIFF
--- a/api.py
+++ b/api.py
@@ -14,7 +14,11 @@ from resources.Capability import (
     ContactCapabilitySuggestionOne,
 )
 from resources.Session import Session
-from resources.ProgramContacts import ProgramContactOne, ProgramContactAll
+from resources.ProgramContacts import (
+    ProgramContactOne,
+    ProgramContactAll,
+    ProgramContactApproveMany
+)
 from resources.Trello_Intake_Talent import (
     IntakeTalentBoard,
     IntakeTalentCard,
@@ -113,6 +117,9 @@ api.add_resource(ProgramContactAll,
 api.add_resource(ProgramContactOne,
                  '/contacts/<int:contact_id>/programs/<int:program_id>',
                  '/contacts/<int:contact_id>/programs/<int:program_id>/')
+api.add_resource(ProgramContactApproveMany,
+                 '/programs/<int:program_id>/contacts/approve-many',
+                 '/programs/<int:program_id>/contacts/approve-many/')
 api.add_resource(OpportunityAppOne,
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>',
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>/')

--- a/models/contact_model.py
+++ b/models/contact_model.py
@@ -68,9 +68,9 @@ class Contact(db.Model):
     achievements = db.relationship('Achievement', back_populates='contact',
                                    cascade='all, delete, delete-orphan')
 
-    skill_items = db.relationship('ContactSkill', 
+    skill_items = db.relationship('ContactSkill',
                            cascade='all, delete, delete-orphan')
-    capability_skill_suggestions = db.relationship('CapabilitySkillSuggestion', 
+    capability_skill_suggestions = db.relationship('CapabilitySkillSuggestion',
                            cascade='all, delete, delete-orphan')
 
     experiences = db.relationship('Experience', back_populates='contact',
@@ -131,3 +131,6 @@ class ContactShortSchema(Schema):
     first_name = fields.String()
     last_name = fields.String()
     email = fields.String(dump_only=True)
+
+    class Meta:
+        unknown = EXCLUDE

--- a/tests/populate_db.py
+++ b/tests/populate_db.py
@@ -313,6 +313,14 @@ billy_pfp = ProgramContact(
     is_approved=True
 )
 
+obama_pfp = ProgramContact(
+    id=6,
+    program_id=1,
+    contact_id=124,
+    card_id='card',
+    stage=1,
+)
+
 r_billy1 = Response(
     id=6,
     program_contact_id=5,
@@ -414,6 +422,7 @@ def populate(db):
     db.session.add(q_pfp1)
     db.session.add(q_pfp2)
     db.session.add(billy_pfp)
+    db.session.add(obama_pfp)
     db.session.add(r_billy1)
     db.session.add(r_billy2)
     db.session.add(review_billy)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -176,6 +176,16 @@ PROGRAM_CONTACTS = {
         'reviews': [
             REVIEWS['review_billy']
         ]
+    },
+    'obama_pfp': {
+        'id': 6,
+        'contact_id': 124,
+        'program': PROGRAMS['pfp'],
+        'card_id': 'card',
+        'stage': 1,
+        'is_active': True,
+        'is_approved': False,
+        'reviews': []
     }
 }
 
@@ -273,7 +283,7 @@ CONTACTS = {
         'pronouns_other': 'They/Them/Their',
         'account_id': None,
         'skills': SKILLS['obama'],
-        'programs': [],
+        'programs': [PROGRAM_CONTACTS['obama_pfp']],
         'terms_agreement': True
     },
 }
@@ -1259,6 +1269,37 @@ def test_opportunity_app_reopen(app):
         assert response.status_code == 200
         assert OpportunityApp.query.get('a1').stage == ApplicationStage.draft.value
 
+
+def test_approve_many_program_contacts(app):
+    mimetype = 'application/json'
+    headers = {
+        'Content-Type': mimetype,
+        'Accept': mimetype
+    }
+    payload = [CONTACTS_SHORT['obama']]
+    with app.test_client() as client:
+        assert ProgramContact.query.get(6).is_approved == False
+        response = client.post('/api/programs/1/contacts/approve-many/',
+                              data=json.dumps(payload),
+                              headers=headers)
+        assert response.status_code == 200
+        assert ProgramContact.query.get(6).is_approved == True
+
+def test_reapprove_eligible_program_contact(app):
+    mimetype = 'application/json'
+    headers = {
+        'Content-Type': mimetype,
+        'Accept': mimetype
+    }
+    payload = [CONTACTS_SHORT['billy']]
+    with app.test_client() as client:
+        assert ProgramContact.query.get(5).is_approved == True
+        response = client.post('/api/programs/1/contacts/approve-many/',
+                              data=json.dumps(payload),
+                              headers=headers)
+        assert response.status_code == 400
+        message = json.loads(response.data)['message']
+        assert message == 'Payload included contacts who were already approved'
 
 @pytest.mark.parametrize(
     "delete_url,query",


### PR DESCRIPTION
Creates endpoint to approve a contact for matching: `POST api/programs/<program_id>/contacts/approve-many/` which expects the payload:
```
[{"id": <int: contact_id>,
  "first_name": <str: first_name>,
  "last_name": <str: last_name>,
  "email": <str: email>},
  {...}]
```

Considerations for deployment:

- **Heroku Variables:** N/A
- **DB Migrations:** N/A
- **AuthZ/N Changes:**  Uses permission `write:all-users`
- **Deployment Sequence:** Backend before frontend