### PR TITLE
Feature get internal applications

### DIFF
--- a/api.py
+++ b/api.py
@@ -17,7 +17,8 @@ from resources.Session import Session
 from resources.ProgramContacts import (
     ProgramContactOne,
     ProgramContactAll,
-    ProgramContactApproveMany
+    ProgramContactApproveMany,
+    ApplicationsInternal
 )
 from resources.Trello_Intake_Talent import (
     IntakeTalentBoard,
@@ -120,6 +121,9 @@ api.add_resource(ProgramContactOne,
 api.add_resource(ProgramContactApproveMany,
                  '/programs/<int:program_id>/contacts/approve-many',
                  '/programs/<int:program_id>/contacts/approve-many/')
+api.add_resource(ApplicationsInternal,
+                 '/internal/applications',
+                 '/internal/applications/')
 api.add_resource(OpportunityAppOne,
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>',
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>/')
@@ -161,7 +165,7 @@ api.add_resource(OpportunityAll,
                  '/opportunity/')
 api.add_resource(OpportunityAllInternal,
                  '/internal/opportunities/',
-                 'internal/opportunities')
+                 '/internal/opportunities')
 api.add_resource(OpportunityOne,
                  '/opportunity/<string:opportunity_id>',
                  '/opportunity/<string:opportunity_id>/')

--- a/models/opportunity_app_model.py
+++ b/models/opportunity_app_model.py
@@ -39,6 +39,9 @@ class OpportunityApp(db.Model):
     def status(self):
         return ApplicationStage(self.stage)
 
+    @hybrid_property
+    def program_id(self):
+        return self.opportunity.cycle.program_id
 
     # for more info on why to use setattr() read this:
     # https://medium.com/@s.azad4/modifying-python-objects-within-the-sqlalchemy-framework-7b6c8dd71ab3

--- a/models/opportunity_model.py
+++ b/models/opportunity_model.py
@@ -1,6 +1,6 @@
 from models.base_model import db
 from models.cycle_model import Cycle, CycleSchema
-from models.contact_model import ContactSchema
+from models.contact_model import ContactSchema, ContactShortSchema
 from models.opportunity_app_model import ApplicationStage
 from models.resume_model import ResumeSnapshotSchema
 from marshmallow import Schema, fields, EXCLUDE
@@ -63,6 +63,21 @@ class OpportunitySchema(Schema):
     cycle_id = fields.Integer(required=True)
     program_id = fields.Integer(attribute='cycle.program_id', dump_only=True)
     applications = fields.Nested(OpportunityAppSchema(exclude=('opportunity',), many=True))
+
+    class Meta:
+        unknown = EXCLUDE
+
+class ProgramContactShortSchema(Schema):
+    id = fields.Integer(dump_only=True)
+    contact = fields.Nested(ContactShortSchema, dump_only=True)
+    program_id = fields.Integer(dump_only=True)
+    is_approved = fields.Boolean(dump_only=True)
+    is_active = fields.Boolean(dump_only=True)
+    applications = fields.Nested(
+        OpportunityAppSchema,
+        only=['id', 'status', 'is_active', 'opportunity'],
+        many=True
+    )
 
     class Meta:
         unknown = EXCLUDE

--- a/models/program_contact_model.py
+++ b/models/program_contact_model.py
@@ -3,6 +3,7 @@ from marshmallow import Schema, fields, EXCLUDE
 from models.program_model import Program, ProgramSchema
 from models.response_model import Response, ResponseSchema
 from models.review_model import Review, ReviewSchema
+from sqlalchemy.ext.hybrid import hybrid_property
 
 
 class ProgramContact(db.Model):
@@ -34,6 +35,11 @@ class ProgramContact(db.Model):
             if field in UPDATE_FIELDS:
                 setattr(self, field, value)
         db.session.commit()
+
+    @hybrid_property
+    def applications(self):
+        return [app for app in self.contact.applications
+                if app.program_id == self.program_id]
 
 class ProgramContactSchema(Schema):
     id = fields.Integer(dump_only=True)

--- a/tests/populate_db.py
+++ b/tests/populate_db.py
@@ -276,9 +276,26 @@ program_pfp = Program(
     name='Place for Purpose',
 )
 
+program_mayoral = Program(
+    id=2,
+    name='Mayoral Fellowship',
+)
+
 cycle_pfp = Cycle(
     id=2,
     program_id=1,
+    date_start=date(2020, 1, 6),
+    date_end=date(2025, 1, 6),
+    intake_talent_board_id='5e37744114d9d01a03ddbcfe',
+    intake_org_board_id='intake_org',
+    match_talent_board_id='match_talent',
+    match_opp_board_id='5e4acd35a35ee523c71f9e25',
+    review_talent_board_id='5e3753cdaea77d37fce3496a',
+)
+
+cycle_mayoral = Cycle(
+    id=3,
+    program_id=2,
     date_start=date(2020, 1, 6),
     date_end=date(2025, 1, 6),
     intake_talent_board_id='5e37744114d9d01a03ddbcfe',
@@ -307,6 +324,15 @@ q_pfp2 = Question(
 billy_pfp = ProgramContact(
     id=5,
     program_id=1,
+    contact_id=123,
+    card_id='card',
+    stage=1,
+    is_approved=True
+)
+
+billy_mayoral = ProgramContact(
+    id=7,
+    program_id=2,
     contact_id=123,
     card_id='card',
     stage=1,
@@ -362,7 +388,7 @@ test_opp2 = Opportunity(
     card_id="card",
     gdoc_link="https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit",
     org_name="Test Org",
-    cycle_id=2,
+    cycle_id=3,
 )
 
 snapshot1 = ResumeSnapshot(
@@ -418,10 +444,13 @@ def populate(db):
     #db.session.add(skill_health)
     #db.session.add(skill_obama_health)
     db.session.add(program_pfp)
+    db.session.add(program_mayoral)
     db.session.add(cycle_pfp)
+    db.session.add(cycle_mayoral)
     db.session.add(q_pfp1)
     db.session.add(q_pfp2)
     db.session.add(billy_pfp)
+    db.session.add(billy_mayoral)
     db.session.add(obama_pfp)
     db.session.add(r_billy1)
     db.session.add(r_billy2)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -128,6 +128,18 @@ CYCLES = {
         'match_opp_board_id': '5e4acd35a35ee523c71f9e25',
         'is_active': True,
         'review_talent_board_id': '5e3753cdaea77d37fce3496a'
+    },
+    'mayoral': {
+        'id': 3,
+        'program_id': 2,
+        'date_start': '2020-01-06',
+        'date_end': '2025-01-06',
+        'intake_talent_board_id': '5e37744114d9d01a03ddbcfe',
+        'intake_org_board_id': 'intake_org',
+        'match_talent_board_id': 'match_talent',
+        'match_opp_board_id': '5e4acd35a35ee523c71f9e25',
+        'is_active': True,
+        'review_talent_board_id': '5e3753cdaea77d37fce3496a'
     }
 }
 
@@ -136,6 +148,11 @@ PROGRAMS = {
         'id': 1,
         'name': 'Place for Purpose',
         'current_cycle': CYCLES['pfp']
+    },
+    'mayoral': {
+        'id': 2,
+        'name': 'Mayoral Fellowship',
+        'current_cycle': CYCLES['mayoral']
     }
 }
 
@@ -186,6 +203,16 @@ PROGRAM_CONTACTS = {
         'is_active': True,
         'is_approved': False,
         'reviews': []
+    },
+    'billy_mayoral': {
+        'id': 7,
+        'contact_id': 123,
+        'program': PROGRAMS['mayoral'],
+        'card_id': 'card',
+        'stage': 1,
+        'is_active': True,
+        'is_approved': True,
+        'reviews': []
     }
 }
 
@@ -219,8 +246,8 @@ OPPORTUNITIES = {
         'gdoc_link': "https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit",
         'status': 'submitted',
         'org_name': 'Test Org',
-        'cycle_id': 2,
-        'program_id': 1
+        'cycle_id': 3,
+        'program_id': 2
     },
 
 }
@@ -253,7 +280,8 @@ CONTACTS = {
         'pronouns_other': None,
         'account_id': 'test-valid|0123456789abcdefabcdefff',
         'skills': SKILLS['billy'],
-        'programs': [PROGRAM_CONTACTS['billy_pfp']],
+        'programs': [PROGRAM_CONTACTS['billy_pfp'],
+                     PROGRAM_CONTACTS['billy_mayoral']],
         'terms_agreement': True
     },
 
@@ -312,6 +340,58 @@ SNAPSHOTS = {
     },
 }
 
+APPLICATIONS_INTERNAL = {
+    'billy_pfp': {
+        'id': 5,
+        'is_approved': True,
+        'is_active': True,
+        'program_id': 1,
+        'contact': {
+            'id': 123,
+            'first_name': 'Billy',
+            'last_name': 'Daly',
+            'email': 'billy@example.com',
+        },
+        'applications': [{
+            'id': 'a1',
+            'status': 'submitted',
+            'is_active': True,
+            'opportunity': OPPORTUNITIES['test_opp1']
+        }]
+    },
+    'obama_pfp': {
+        'contact': {
+            'email': 'obama@whitehouse.gov',
+            'first_name': 'Barack',
+            'id': 124,
+            'last_name': 'Obama'},
+        'id': 6,
+        'is_active': True,
+        'is_approved': False,
+        'program_id': 1,
+        'applications': []
+    },
+    'billy_mayoral': {
+        'id': 7,
+        'is_approved': True,
+        'is_active': True,
+        'program_id': 2,
+        'contact': {
+            'id': 123,
+            'first_name': 'Billy',
+            'last_name': 'Daly',
+            'email': 'billy@example.com',
+        },
+        'applications': [
+        {
+            'id': 'a2',
+            'status': 'draft',
+            'is_active': True,
+            'opportunity': OPPORTUNITIES['test_opp2']
+        }]
+    },
+}
+
 OPPORTUNITIES_INTERNAL = {
     'test_opp1': {
         'id': '123abc',
@@ -336,8 +416,8 @@ OPPORTUNITIES_INTERNAL = {
         'gdoc_link': "https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit",
         'status': 'submitted',
         'org_name': 'Test Org',
-        'cycle_id': 2,
-        'program_id': 1,
+        'cycle_id': 3,
+        'program_id': 2,
         'applications': [{'id': 'a2',
                           'contact': CONTACTS['billy'],
                           'interest_statement': "I'm also interested in this test opportunity",
@@ -1435,11 +1515,16 @@ def test_get_capability_recommendations(app):
                                          EXPERIENCES['baltimore']])
     ,('/api/contacts/124/experiences/', [EXPERIENCES['columbia']])
     ,('/api/contacts/123/achievements/', ACHIEVEMENTS.values())
-    ,('/api/contacts/123/programs/', [PROGRAM_CONTACTS['billy_pfp']])
+    ,('/api/contacts/123/programs/', [PROGRAM_CONTACTS['billy_pfp'], PROGRAM_CONTACTS['billy_mayoral']])
     ,('/api/opportunity/', OPPORTUNITIES.values())
     ,('/api/contacts/123/app/', [APPLICATIONS['app_billy']])
     ,('/api/internal/opportunities/', OPPORTUNITIES_INTERNAL.values())
     ,('/api/contacts/short/', CONTACTS_SHORT.values())
+    ,('/api/internal/applications/', APPLICATIONS_INTERNAL.values())
+    ,('/api/internal/applications/?program_id=1',
+      [APPLICATIONS_INTERNAL['billy_pfp'], APPLICATIONS_INTERNAL['obama_pfp']])
+    ,('/api/internal/applications/?program_id=2',
+      [APPLICATIONS_INTERNAL['billy_mayoral']])
     ]
 )
 def test_get_many_unordered(app, url, expected):
@@ -1455,8 +1540,8 @@ def test_get_many_unordered(app, url, expected):
 
         # Test that the data and expected contain the same items, but not
         # necessarily in the same order
-        assert len(data) == len(expected)
         pprint(list(expected))
+        assert len(data) == len(expected)
         for item in data:
             pprint(item)
             assert item in expected

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1520,9 +1520,11 @@ def test_get_capability_recommendations(app):
     ,('/api/contacts/123/app/', [APPLICATIONS['app_billy']])
     ,('/api/internal/opportunities/', OPPORTUNITIES_INTERNAL.values())
     ,('/api/contacts/short/', CONTACTS_SHORT.values())
-    ,('/api/internal/applications/', APPLICATIONS_INTERNAL.values())
+    ,('/api/internal/applications/',
+      [APPLICATIONS_INTERNAL['billy_pfp'],
+       APPLICATIONS_INTERNAL['billy_mayoral']])
     ,('/api/internal/applications/?program_id=1',
-      [APPLICATIONS_INTERNAL['billy_pfp'], APPLICATIONS_INTERNAL['obama_pfp']])
+      [APPLICATIONS_INTERNAL['billy_pfp']])
     ,('/api/internal/applications/?program_id=2',
       [APPLICATIONS_INTERNAL['billy_mayoral']])
     ]


### PR DESCRIPTION
Creates endpoint `GET api/internal/applications/?program_id=<program_id>` which returns a list of applicants and the opportunities they've applied for with the following format
```
{"id": int,
 "is_approved": bool,
 "stage": int,
 "contact": {
     "id": int,
     "first_name": str,
     "last_name": str,
     "email": str
 },
 "applications": [{
     "id": str,
     "status": enum,
     "opportunity": {
           "id": str,
           "title": str,
           "org_name": str
     }
 }]}
```

Considerations for deployment:

Heroku Variables: N/A
DB Migrations: N/A
AuthZ/N Changes: Creates permission view: app-internal
Deployment Sequence: Backend before frontend