### PR TITLE
Staging staff internal candidate view

### DIFF
--- a/api.py
+++ b/api.py
@@ -17,7 +17,8 @@ from resources.Session import Session
 from resources.ProgramContacts import (
     ProgramContactOne,
     ProgramContactAll,
-    ProgramContactApproveMany
+    ProgramContactApproveMany,
+    ApplicationsInternal
 )
 from resources.Trello_Intake_Talent import (
     IntakeTalentBoard,
@@ -120,6 +121,9 @@ api.add_resource(ProgramContactOne,
 api.add_resource(ProgramContactApproveMany,
                  '/programs/<int:program_id>/contacts/approve-many',
                  '/programs/<int:program_id>/contacts/approve-many/')
+api.add_resource(ApplicationsInternal,
+                 '/internal/applications',
+                 '/internal/applications/')
 api.add_resource(OpportunityAppOne,
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>',
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>/')
@@ -161,7 +165,7 @@ api.add_resource(OpportunityAll,
                  '/opportunity/')
 api.add_resource(OpportunityAllInternal,
                  '/internal/opportunities/',
-                 'internal/opportunities')
+                 '/internal/opportunities')
 api.add_resource(OpportunityOne,
                  '/opportunity/<string:opportunity_id>',
                  '/opportunity/<string:opportunity_id>/')

--- a/api.py
+++ b/api.py
@@ -1,6 +1,6 @@
 from flask import Blueprint
 from flask_restful import Api
-from resources.Contacts import ContactAll, ContactOne, ContactAccount
+from resources.Contacts import ContactAll, ContactOne, ContactAccount, ContactShort
 from resources.Tag import TagAll, TagOne, TagItemAll, TagItemOne
 from resources.Experience import ExperienceAll, ExperienceOne
 from resources.Achievement import AchievementAll
@@ -48,6 +48,9 @@ api.add_resource(ContactOne,
 api.add_resource(ContactAccount,
                  '/contacts/me',
                  '/contacts/me/')
+api.add_resource(ContactShort,
+                 '/contacts/short',
+                 '/contacts/short/')
 api.add_resource(ContactSkills,
                  '/contacts/<int:contact_id>/skills',
                  '/contacts/<int:contact_id>/skills/')

--- a/api.py
+++ b/api.py
@@ -14,7 +14,11 @@ from resources.Capability import (
     ContactCapabilitySuggestionOne,
 )
 from resources.Session import Session
-from resources.ProgramContacts import ProgramContactOne, ProgramContactAll
+from resources.ProgramContacts import (
+    ProgramContactOne,
+    ProgramContactAll,
+    ProgramContactApproveMany
+)
 from resources.Trello_Intake_Talent import (
     IntakeTalentBoard,
     IntakeTalentCard,
@@ -113,6 +117,9 @@ api.add_resource(ProgramContactAll,
 api.add_resource(ProgramContactOne,
                  '/contacts/<int:contact_id>/programs/<int:program_id>',
                  '/contacts/<int:contact_id>/programs/<int:program_id>/')
+api.add_resource(ProgramContactApproveMany,
+                 '/programs/<int:program_id>/contacts/approve-many',
+                 '/programs/<int:program_id>/contacts/approve-many/')
 api.add_resource(OpportunityAppOne,
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>',
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>/')

--- a/models/contact_model.py
+++ b/models/contact_model.py
@@ -100,6 +100,9 @@ class Contact(db.Model):
                 skills.append(skill_item.skill)
         return sorted(skills, key=lambda skill: skill.name)
 
+    @hybrid_property
+    def email(self):
+        return self.email_primary.email
 
 class ContactSchema(Schema):
     id = fields.Integer(dump_only=True)
@@ -122,3 +125,9 @@ class ContactSchema(Schema):
 
     class Meta:
         unknown = EXCLUDE
+
+class ContactShortSchema(Schema):
+    id = fields.Integer()
+    first_name = fields.String()
+    last_name = fields.String()
+    email = fields.String(dump_only=True)

--- a/models/contact_model.py
+++ b/models/contact_model.py
@@ -68,9 +68,9 @@ class Contact(db.Model):
     achievements = db.relationship('Achievement', back_populates='contact',
                                    cascade='all, delete, delete-orphan')
 
-    skill_items = db.relationship('ContactSkill', 
+    skill_items = db.relationship('ContactSkill',
                            cascade='all, delete, delete-orphan')
-    capability_skill_suggestions = db.relationship('CapabilitySkillSuggestion', 
+    capability_skill_suggestions = db.relationship('CapabilitySkillSuggestion',
                            cascade='all, delete, delete-orphan')
 
     experiences = db.relationship('Experience', back_populates='contact',
@@ -131,3 +131,6 @@ class ContactShortSchema(Schema):
     first_name = fields.String()
     last_name = fields.String()
     email = fields.String(dump_only=True)
+
+    class Meta:
+        unknown = EXCLUDE

--- a/models/opportunity_app_model.py
+++ b/models/opportunity_app_model.py
@@ -39,6 +39,9 @@ class OpportunityApp(db.Model):
     def status(self):
         return ApplicationStage(self.stage)
 
+    @hybrid_property
+    def program_id(self):
+        return self.opportunity.cycle.program_id
 
     # for more info on why to use setattr() read this:
     # https://medium.com/@s.azad4/modifying-python-objects-within-the-sqlalchemy-framework-7b6c8dd71ab3

--- a/models/opportunity_model.py
+++ b/models/opportunity_model.py
@@ -1,6 +1,6 @@
 from models.base_model import db
 from models.cycle_model import Cycle, CycleSchema
-from models.contact_model import ContactSchema
+from models.contact_model import ContactSchema, ContactShortSchema
 from models.opportunity_app_model import ApplicationStage
 from models.resume_model import ResumeSnapshotSchema
 from marshmallow import Schema, fields, EXCLUDE
@@ -63,6 +63,21 @@ class OpportunitySchema(Schema):
     cycle_id = fields.Integer(required=True)
     program_id = fields.Integer(attribute='cycle.program_id', dump_only=True)
     applications = fields.Nested(OpportunityAppSchema(exclude=('opportunity',), many=True))
+
+    class Meta:
+        unknown = EXCLUDE
+
+class ProgramContactShortSchema(Schema):
+    id = fields.Integer(dump_only=True)
+    contact = fields.Nested(ContactShortSchema, dump_only=True)
+    program_id = fields.Integer(dump_only=True)
+    is_approved = fields.Boolean(dump_only=True)
+    is_active = fields.Boolean(dump_only=True)
+    applications = fields.Nested(
+        OpportunityAppSchema,
+        only=['id', 'status', 'is_active', 'opportunity'],
+        many=True
+    )
 
     class Meta:
         unknown = EXCLUDE

--- a/models/program_contact_model.py
+++ b/models/program_contact_model.py
@@ -3,6 +3,7 @@ from marshmallow import Schema, fields, EXCLUDE
 from models.program_model import Program, ProgramSchema
 from models.response_model import Response, ResponseSchema
 from models.review_model import Review, ReviewSchema
+from sqlalchemy.ext.hybrid import hybrid_property
 
 
 class ProgramContact(db.Model):
@@ -34,6 +35,11 @@ class ProgramContact(db.Model):
             if field in UPDATE_FIELDS:
                 setattr(self, field, value)
         db.session.commit()
+
+    @hybrid_property
+    def applications(self):
+        return [app for app in self.contact.applications
+                if app.program_id == self.program_id]
 
 class ProgramContactSchema(Schema):
     id = fields.Integer(dump_only=True)

--- a/resources/Contacts.py
+++ b/resources/Contacts.py
@@ -2,7 +2,7 @@ from flask import request as reqobj #ask David why this is here
 from flask import current_app
 from flask_restful import Resource, request
 from flask_login import login_user, current_user, login_required
-from models.contact_model import Contact, ContactSchema
+from models.contact_model import Contact, ContactSchema, ContactShortSchema
 from models.email_model import Email
 from models.address_model import Address
 from models.base_model import db
@@ -27,6 +27,7 @@ from .skill_utils import get_skill_id, get_or_make_skill
 
 contact_schema = ContactSchema()
 contacts_schema = ContactSchema(many=True)
+contacts_short_schema = ContactShortSchema(many=True)
 
 def add_skills(skills, contact):
     for skill_data in skills:
@@ -88,6 +89,20 @@ class ContactAll(Resource):
         result = contact_schema.dump(contact)
         return {"status": 'success', 'data': result}, 201
 
+class ContactShort(Resource):
+    method_decorators = {
+        'get': [login_required, refresh_session],
+    }
+
+    def get(self):
+        if not is_authorized_with_permission('view:all-users'):
+            return unauthorized()
+
+        contacts = Contact.query.all()
+
+        contacts = contacts_short_schema.dump(contacts)
+        return {'status': 'success', 'data': contacts}, 200
+
 class ContactAccount(Resource):
     method_decorators = {
         'get': [validate_jwt],
@@ -112,7 +127,7 @@ class ContactOne(Resource):
         contact = Contact.query.get(contact_id)
         if not contact:
             return {'message': 'Contact does not exist'}, 404
-        if not is_authorized_view(contact.id): 
+        if not is_authorized_view(contact.id):
             return unauthorized()
         contact = contact_schema.dump(contact)
         return {'status': 'success', 'data': contact}, 200
@@ -121,7 +136,7 @@ class ContactOne(Resource):
         contact = Contact.query.get(contact_id)
         if not contact:
             return {'message': 'Contact does not exist'}, 404
-        if not is_authorized_write(contact.id): 
+        if not is_authorized_write(contact.id):
             return unauthorized()
         json_data = request.get_json(force=True)
         try:

--- a/tests/populate_db.py
+++ b/tests/populate_db.py
@@ -313,6 +313,14 @@ billy_pfp = ProgramContact(
     is_approved=True
 )
 
+obama_pfp = ProgramContact(
+    id=6,
+    program_id=1,
+    contact_id=124,
+    card_id='card',
+    stage=1,
+)
+
 r_billy1 = Response(
     id=6,
     program_contact_id=5,
@@ -414,6 +422,7 @@ def populate(db):
     db.session.add(q_pfp1)
     db.session.add(q_pfp2)
     db.session.add(billy_pfp)
+    db.session.add(obama_pfp)
     db.session.add(r_billy1)
     db.session.add(r_billy2)
     db.session.add(review_billy)

--- a/tests/populate_db.py
+++ b/tests/populate_db.py
@@ -276,9 +276,26 @@ program_pfp = Program(
     name='Place for Purpose',
 )
 
+program_mayoral = Program(
+    id=2,
+    name='Mayoral Fellowship',
+)
+
 cycle_pfp = Cycle(
     id=2,
     program_id=1,
+    date_start=date(2020, 1, 6),
+    date_end=date(2025, 1, 6),
+    intake_talent_board_id='5e37744114d9d01a03ddbcfe',
+    intake_org_board_id='intake_org',
+    match_talent_board_id='match_talent',
+    match_opp_board_id='5e4acd35a35ee523c71f9e25',
+    review_talent_board_id='5e3753cdaea77d37fce3496a',
+)
+
+cycle_mayoral = Cycle(
+    id=3,
+    program_id=2,
     date_start=date(2020, 1, 6),
     date_end=date(2025, 1, 6),
     intake_talent_board_id='5e37744114d9d01a03ddbcfe',
@@ -307,6 +324,15 @@ q_pfp2 = Question(
 billy_pfp = ProgramContact(
     id=5,
     program_id=1,
+    contact_id=123,
+    card_id='card',
+    stage=1,
+    is_approved=True
+)
+
+billy_mayoral = ProgramContact(
+    id=7,
+    program_id=2,
     contact_id=123,
     card_id='card',
     stage=1,
@@ -362,7 +388,7 @@ test_opp2 = Opportunity(
     card_id="card",
     gdoc_link="https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit",
     org_name="Test Org",
-    cycle_id=2,
+    cycle_id=3,
 )
 
 snapshot1 = ResumeSnapshot(
@@ -418,10 +444,13 @@ def populate(db):
     #db.session.add(skill_health)
     #db.session.add(skill_obama_health)
     db.session.add(program_pfp)
+    db.session.add(program_mayoral)
     db.session.add(cycle_pfp)
+    db.session.add(cycle_mayoral)
     db.session.add(q_pfp1)
     db.session.add(q_pfp2)
     db.session.add(billy_pfp)
+    db.session.add(billy_mayoral)
     db.session.add(obama_pfp)
     db.session.add(r_billy1)
     db.session.add(r_billy2)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -128,6 +128,18 @@ CYCLES = {
         'match_opp_board_id': '5e4acd35a35ee523c71f9e25',
         'is_active': True,
         'review_talent_board_id': '5e3753cdaea77d37fce3496a'
+    },
+    'mayoral': {
+        'id': 3,
+        'program_id': 2,
+        'date_start': '2020-01-06',
+        'date_end': '2025-01-06',
+        'intake_talent_board_id': '5e37744114d9d01a03ddbcfe',
+        'intake_org_board_id': 'intake_org',
+        'match_talent_board_id': 'match_talent',
+        'match_opp_board_id': '5e4acd35a35ee523c71f9e25',
+        'is_active': True,
+        'review_talent_board_id': '5e3753cdaea77d37fce3496a'
     }
 }
 
@@ -136,6 +148,11 @@ PROGRAMS = {
         'id': 1,
         'name': 'Place for Purpose',
         'current_cycle': CYCLES['pfp']
+    },
+    'mayoral': {
+        'id': 2,
+        'name': 'Mayoral Fellowship',
+        'current_cycle': CYCLES['mayoral']
     }
 }
 
@@ -186,6 +203,16 @@ PROGRAM_CONTACTS = {
         'is_active': True,
         'is_approved': False,
         'reviews': []
+    },
+    'billy_mayoral': {
+        'id': 7,
+        'contact_id': 123,
+        'program': PROGRAMS['mayoral'],
+        'card_id': 'card',
+        'stage': 1,
+        'is_active': True,
+        'is_approved': True,
+        'reviews': []
     }
 }
 
@@ -219,8 +246,8 @@ OPPORTUNITIES = {
         'gdoc_link': "https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit",
         'status': 'submitted',
         'org_name': 'Test Org',
-        'cycle_id': 2,
-        'program_id': 1
+        'cycle_id': 3,
+        'program_id': 2
     },
 
 }
@@ -253,7 +280,8 @@ CONTACTS = {
         'pronouns_other': None,
         'account_id': 'test-valid|0123456789abcdefabcdefff',
         'skills': SKILLS['billy'],
-        'programs': [PROGRAM_CONTACTS['billy_pfp']],
+        'programs': [PROGRAM_CONTACTS['billy_pfp'],
+                     PROGRAM_CONTACTS['billy_mayoral']],
         'terms_agreement': True
     },
 
@@ -312,6 +340,58 @@ SNAPSHOTS = {
     },
 }
 
+APPLICATIONS_INTERNAL = {
+    'billy_pfp': {
+        'id': 5,
+        'is_approved': True,
+        'is_active': True,
+        'program_id': 1,
+        'contact': {
+            'id': 123,
+            'first_name': 'Billy',
+            'last_name': 'Daly',
+            'email': 'billy@example.com',
+        },
+        'applications': [{
+            'id': 'a1',
+            'status': 'submitted',
+            'is_active': True,
+            'opportunity': OPPORTUNITIES['test_opp1']
+        }]
+    },
+    'obama_pfp': {
+        'contact': {
+            'email': 'obama@whitehouse.gov',
+            'first_name': 'Barack',
+            'id': 124,
+            'last_name': 'Obama'},
+        'id': 6,
+        'is_active': True,
+        'is_approved': False,
+        'program_id': 1,
+        'applications': []
+    },
+    'billy_mayoral': {
+        'id': 7,
+        'is_approved': True,
+        'is_active': True,
+        'program_id': 2,
+        'contact': {
+            'id': 123,
+            'first_name': 'Billy',
+            'last_name': 'Daly',
+            'email': 'billy@example.com',
+        },
+        'applications': [
+        {
+            'id': 'a2',
+            'status': 'draft',
+            'is_active': True,
+            'opportunity': OPPORTUNITIES['test_opp2']
+        }]
+    },
+}
+
 OPPORTUNITIES_INTERNAL = {
     'test_opp1': {
         'id': '123abc',
@@ -336,8 +416,8 @@ OPPORTUNITIES_INTERNAL = {
         'gdoc_link': "https://docs.google.com/document/d/19Xl2v69Fr2n8iTig4Do9l9BUvTqAwkJY87_fZiDIs4Q/edit",
         'status': 'submitted',
         'org_name': 'Test Org',
-        'cycle_id': 2,
-        'program_id': 1,
+        'cycle_id': 3,
+        'program_id': 2,
         'applications': [{'id': 'a2',
                           'contact': CONTACTS['billy'],
                           'interest_statement': "I'm also interested in this test opportunity",
@@ -1435,11 +1515,18 @@ def test_get_capability_recommendations(app):
                                          EXPERIENCES['baltimore']])
     ,('/api/contacts/124/experiences/', [EXPERIENCES['columbia']])
     ,('/api/contacts/123/achievements/', ACHIEVEMENTS.values())
-    ,('/api/contacts/123/programs/', [PROGRAM_CONTACTS['billy_pfp']])
+    ,('/api/contacts/123/programs/', [PROGRAM_CONTACTS['billy_pfp'], PROGRAM_CONTACTS['billy_mayoral']])
     ,('/api/opportunity/', OPPORTUNITIES.values())
     ,('/api/contacts/123/app/', [APPLICATIONS['app_billy']])
     ,('/api/internal/opportunities/', OPPORTUNITIES_INTERNAL.values())
     ,('/api/contacts/short/', CONTACTS_SHORT.values())
+    ,('/api/internal/applications/',
+      [APPLICATIONS_INTERNAL['billy_pfp'],
+       APPLICATIONS_INTERNAL['billy_mayoral']])
+    ,('/api/internal/applications/?program_id=1',
+      [APPLICATIONS_INTERNAL['billy_pfp']])
+    ,('/api/internal/applications/?program_id=2',
+      [APPLICATIONS_INTERNAL['billy_mayoral']])
     ]
 )
 def test_get_many_unordered(app, url, expected):
@@ -1455,8 +1542,8 @@ def test_get_many_unordered(app, url, expected):
 
         # Test that the data and expected contain the same items, but not
         # necessarily in the same order
-        assert len(data) == len(expected)
         pprint(list(expected))
+        assert len(data) == len(expected)
         for item in data:
             pprint(item)
             assert item in expected

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -278,6 +278,21 @@ CONTACTS = {
     },
 }
 
+CONTACTS_SHORT = {
+    'billy': {
+        'id': 123,
+        'first_name': "Billy",
+        'last_name': "Daly",
+        'email': "billy@example.com",
+    },
+    'obama': {
+        'id': 124,
+        'first_name': "Barack",
+        'last_name': "Obama",
+        'email': "obama@whitehouse.gov",
+    }
+}
+
 SNAPSHOTS = {
     'snapshot1': {
         'test': 'snapshot1'
@@ -1383,6 +1398,7 @@ def test_get_capability_recommendations(app):
     ,('/api/opportunity/', OPPORTUNITIES.values())
     ,('/api/contacts/123/app/', [APPLICATIONS['app_billy']])
     ,('/api/internal/opportunities/', OPPORTUNITIES_INTERNAL.values())
+    ,('/api/contacts/short/', CONTACTS_SHORT.values())
     ]
 )
 def test_get_many_unordered(app, url, expected):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -176,6 +176,16 @@ PROGRAM_CONTACTS = {
         'reviews': [
             REVIEWS['review_billy']
         ]
+    },
+    'obama_pfp': {
+        'id': 6,
+        'contact_id': 124,
+        'program': PROGRAMS['pfp'],
+        'card_id': 'card',
+        'stage': 1,
+        'is_active': True,
+        'is_approved': False,
+        'reviews': []
     }
 }
 
@@ -273,7 +283,7 @@ CONTACTS = {
         'pronouns_other': 'They/Them/Their',
         'account_id': None,
         'skills': SKILLS['obama'],
-        'programs': [],
+        'programs': [PROGRAM_CONTACTS['obama_pfp']],
         'terms_agreement': True
     },
 }
@@ -1259,6 +1269,37 @@ def test_opportunity_app_reopen(app):
         assert response.status_code == 200
         assert OpportunityApp.query.get('a1').stage == ApplicationStage.draft.value
 
+
+def test_approve_many_program_contacts(app):
+    mimetype = 'application/json'
+    headers = {
+        'Content-Type': mimetype,
+        'Accept': mimetype
+    }
+    payload = [CONTACTS_SHORT['obama']]
+    with app.test_client() as client:
+        assert ProgramContact.query.get(6).is_approved == False
+        response = client.post('/api/programs/1/contacts/approve-many/',
+                              data=json.dumps(payload),
+                              headers=headers)
+        assert response.status_code == 200
+        assert ProgramContact.query.get(6).is_approved == True
+
+def test_reapprove_eligible_program_contact(app):
+    mimetype = 'application/json'
+    headers = {
+        'Content-Type': mimetype,
+        'Accept': mimetype
+    }
+    payload = [CONTACTS_SHORT['billy']]
+    with app.test_client() as client:
+        assert ProgramContact.query.get(5).is_approved == True
+        response = client.post('/api/programs/1/contacts/approve-many/',
+                              data=json.dumps(payload),
+                              headers=headers)
+        assert response.status_code == 400
+        message = json.loads(response.data)['message']
+        assert message == 'Payload included contacts who were already approved'
 
 @pytest.mark.parametrize(
     "delete_url,query",


### PR DESCRIPTION
Backend changes:

- Creates endpoint `GET api/contacts/short/` which returns a list of all contacts with a lightweight format: 
 ```
[{first_name: str,
 last_name: str,
 id: int,
 email: str},
 {...}]
```
- Creates endpoint `GET api/internal/applications/?program_id=<program_id>` which returns a list of applicants and the opportunities they've applied for with the following format
```
{"id": int,
 "is_approved": bool,
 "stage": int,
 "contact": {
     "id": int,
     "first_name": str,
     "last_name": str,
     "email": str
 },
 "applications": [{
     "id": str,
     "status": enum,
     "is_active": bool,
     "opportunity": {
           "id": str,
           "title": str,
           "org_name": str
     }
 }]}
```
- Creates endpoint to approve a contact for matching: `POST api/programs/<program_id>/contacts/approve-many/` which expects the payload:
```
[{"id": <int: contact_id>,
  "first_name": <str: first_name>,
  "last_name": <str: last_name>,
  "email": <str: email>},
  {...}]
```


Considerations for deployment:

- **Heroku Variables:** N/A
- **DB Migrations:** N/A
- **AuthZ/N Changes:** creates permissions `view:app-internal` and uses `write:all-users`
- **Deployment Sequence:** Backed before frontend