### PR TITLE
Bug program contact approve

### DIFF
--- a/models/contact_model.py
+++ b/models/contact_model.py
@@ -104,6 +104,10 @@ class Contact(db.Model):
     def email(self):
         return self.email_primary.email
 
+    def query_program_contact(self, program_id):
+        return next((p for p in self.programs
+                     if p.program_id == program_id), None)
+
 class ContactSchema(Schema):
     id = fields.Integer(dump_only=True)
     first_name = fields.String(required=True)

--- a/resources/Contacts.py
+++ b/resources/Contacts.py
@@ -81,6 +81,7 @@ class ContactAll(Resource):
             'program_id': 1
         }
         create_program_contact(contact.id, **program_contact_data)
+        db.session.commit()
         add_new_talent_card(contact.id)
 
         user_session = create_session(contact.id, request.jwt)

--- a/resources/ProgramContacts.py
+++ b/resources/ProgramContacts.py
@@ -39,7 +39,6 @@ def create_program_contact(contact_id, program_id=1, **data):
     data['program_id'] = program_id
     program_contact = ProgramContact(**data)
     db.session.add(program_contact)
-    db.session.commit()
     result = program_contact_schema.dump(program_contact)
     return  result
 


### PR DESCRIPTION
Fixes a design bug in the feature-program-contact-approve branch, which returned an error when a contact included in the payload didn't have an existing program_contact, also removed an error thrown if a contact included in the payload has already been approved.