### PR TITLE
Bug reapprove program contact

### DIFF
--- a/resources/ProgramContacts.py
+++ b/resources/ProgramContacts.py
@@ -39,8 +39,7 @@ def create_program_contact(contact_id, program_id=1, **data):
     data['program_id'] = program_id
     program_contact = ProgramContact(**data)
     db.session.add(program_contact)
-    result = program_contact_schema.dump(program_contact)
-    return  result
+    return  program_contact
 
 class ProgramContactApproveMany(Resource):
     method_decorators = {
@@ -74,11 +73,12 @@ class ProgramContactApproveMany(Resource):
                     'is_approved': True
                 }
                 program_contact = create_program_contact(**insert_data)
+                program_contact.contact = contact
             else:
                 program_contact.is_approved = True
             program_contacts.append(program_contact)
         db.session.commit()
-        result = program_contacts_schema.dump(program_contacts)
+        result = program_contacts_short_schema.dump(program_contacts)
         return {'status': 'success', 'data': result}, 200
 
 class ProgramContactAll(Resource):
@@ -111,7 +111,13 @@ class ProgramContactAll(Resource):
         # checks to see if there's an existing program_contact record
         program = data.pop('program_id')
         contact = data.pop('contact_id')
-        result = create_program_contact(contact_id, program_id=program, **data)
+        program_contact = create_program_contact(
+            contact_id,
+            program_id=program,
+            **data
+        )
+        db.session.commit()
+        result = program_contact_schema.dump(program_contact)
         return {"status": 'success', 'data': result}, 201
 
 class ProgramContactOne(Resource):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1367,14 +1367,22 @@ def test_approve_many_program_contacts_new(app, ):
                               data=json.dumps(payload),
                               headers=headers)
         assert response.status_code == 200
-        data = json.loads(response.data)['data']
-        print(data)
         program_contact = (ProgramContact
                            .query
                            .filter_by(contact_id=124, program_id=2)
                            .first())
         assert program_contact is not None
         assert program_contact.is_approved == True
+        data = json.loads(response.data)['data']
+        obama_mayoral = APPLICATIONS_INTERNAL['obama_pfp'].copy()
+        obama_mayoral['program_id'] = 2
+        obama_mayoral['id'] = 1
+        obama_mayoral['is_approved'] = True
+        expected = [obama_mayoral]
+        print(expected)
+        for item in data:
+            print(item)
+            assert item in expected
 
 def test_approve_many_program_contacts_existing(app, ):
     mimetype = 'application/json'
@@ -1390,6 +1398,37 @@ def test_approve_many_program_contacts_existing(app, ):
                               headers=headers)
         assert response.status_code == 200
         assert ProgramContact.query.get(6).is_approved == True
+        data = json.loads(response.data)['data']
+        expected = [APPLICATIONS_INTERNAL['obama_pfp']]
+        expected[0]['is_approved'] = True
+        print(expected)
+        for item in data:
+            print(item)
+            assert item in expected
+
+def test_reapprove_many_program_contacts(app, ):
+    mimetype = 'application/json'
+    headers = {
+        'Content-Type': mimetype,
+        'Accept': mimetype
+    }
+    payload = [CONTACTS_SHORT['billy'], CONTACTS_SHORT['obama']]
+    with app.test_client() as client:
+        assert ProgramContact.query.get(6).is_approved == False
+        assert ProgramContact.query.get(5).is_approved == True
+        response = client.post('/api/programs/1/contacts/approve-many/',
+                              data=json.dumps(payload),
+                              headers=headers)
+        assert response.status_code == 200
+        assert ProgramContact.query.get(6).is_approved == True
+        assert ProgramContact.query.get(5).is_approved == True
+        data = json.loads(response.data)['data']
+        expected = [APPLICATIONS_INTERNAL['obama_pfp'],
+                    APPLICATIONS_INTERNAL['billy_pfp']]
+        print(expected)
+        for item in data:
+            print(item)
+            assert item in expected
 
 def test_approve_program_contact_fake_contact(app):
     mimetype = 'application/json'


### PR DESCRIPTION
Returns the following response data when `POST programs/<program_id>/contacts/approve-many/` is called:

```
[{"id": int,
   "is_approved": bool,
   "stage": int,
   "contact": {
       "id": int,
       "first_name": str,
       "last_name": str,
       "email": str
   },
   "applications": [{
       "id": str,
       "status": enum,
       "is_active": bool,
       "opportunity": {
           "id": str,
           "title": str,
           "org_name": str
       }
  }]},
  {...}]
```
Deployment Considerations

- **Heroku Variables:** N/A
- **DB Migrations:** N/A
- **AuthZ/N Changes:** N/A
- **Deployment Sequence:** N/A