### PR TITLE
Bug preserve card labels on submit

### DIFF
--- a/resources/FormAssembly.py
+++ b/resources/FormAssembly.py
@@ -92,6 +92,7 @@ class TalentProgramApp(Resource):
         capabilities_str = '\n'.join(capabilities)
         programs = [v for k,v in form_data.items() if 'programs' in k]
         programs_str = '\n'.join(['- ' + p for p in programs ])
+        new_labels = set(card.label_names + programs)
         if form_data.get('mayoral_eligible'):
             mayoral_eligible = form_data.get('mayoral_eligible')
         else:
@@ -136,7 +137,7 @@ class TalentProgramApp(Resource):
             url=f"https://app.formassembly.com/responses/view/{form_data['response_id']}",
             name='Full Response'
         )
-        card.set_labels(programs)
+        card.set_labels(new_labels)
 
         # moves card and updates program_contact to stage 2
         program_contact.update(**{'stage': 2})

--- a/tests/trello_integration_test.py
+++ b/tests/trello_integration_test.py
@@ -74,14 +74,14 @@ def test_talent_intake(app):
 
     for attachment in TALENT_INTAKE_ATTACHMENTS:
         response = card.remove_attachment(attachment)
-    card.set_labels(remove_all=True)
+    card.set_labels(label_names=['New'])
     card.move_card(started_list)
 
     board = Board(query_board_data(board_id))
     card = board.cards.get(card_id)
 
     assert card.attachments == {}
-    assert card.label_names == []
+    assert card.label_names == ['New']
     assert card.stage == 1
 
     url = '/api/form-assembly/talent-app/'
@@ -95,6 +95,7 @@ def test_talent_intake(app):
         board = Board(query_board_data(board_id))
         card = board.cards.get(card_id)
         assert card.stage == 2
+        assert 'New' in card.label_names
         for label in TALENT_INTAKE_LABELS[1:]:
             assert label in card.label_names
         assert 'Race' in card.desc

--- a/tests/trello_integration_test.py
+++ b/tests/trello_integration_test.py
@@ -74,14 +74,14 @@ def test_talent_intake(app):
 
     for attachment in TALENT_INTAKE_ATTACHMENTS:
         response = card.remove_attachment(attachment)
-    card.set_labels(label_names=['New'])
+    card.set_labels(label_names=['New', 'Fellowship'])
     card.move_card(started_list)
 
     board = Board(query_board_data(board_id))
     card = board.cards.get(card_id)
 
     assert card.attachments == {}
-    assert card.label_names == ['New']
+    assert card.label_names == ['New', 'Fellowship']
     assert card.stage == 1
 
     url = '/api/form-assembly/talent-app/'


### PR DESCRIPTION
Preserves the existing labels on the card when a talent application form is submitted and new labels are applied