### PR TITLE
Staging trello bug fixes

### DIFF
--- a/models/achievement_model.py
+++ b/models/achievement_model.py
@@ -14,7 +14,7 @@ class Achievement(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     exp_id = db.Column(db.Integer, db.ForeignKey('experience.id'), nullable=False)
     contact_id = db.Column(db.Integer, db.ForeignKey('contact.id'), nullable=False)
-    description = db.Column(db.String(2000))
+    description = db.Column(db.String)
 
     #relationships
     experience = db.relationship('Experience', back_populates='achievements')

--- a/models/experience_model.py
+++ b/models/experience_model.py
@@ -46,12 +46,12 @@ class Experience(db.Model):
 
     #table columns
     id = db.Column(db.Integer, primary_key=True)
-    description = db.Column(db.String(2000))
-    host = db.Column(db.String(100), nullable=False)
-    title = db.Column(db.String(100), nullable=False)
+    description = db.Column(db.String)
+    host = db.Column(db.String, nullable=False)
+    title = db.Column(db.String, nullable=False)
     degree_other = db.Column(db.String(100))
     degree = db.Column(db.String(100))
-    link = db.Column(db.String(255))
+    link = db.Column(db.String)
     start_month = db.Column(db.Enum(Month, name='MonthType'), nullable=False)
     start_year = db.Column(db.Integer, nullable=False)
     end_month = db.Column(db.Enum(Month, name='MonthType'), nullable=False)

--- a/resources/FormAssembly.py
+++ b/resources/FormAssembly.py
@@ -85,6 +85,8 @@ class TalentProgramApp(Resource):
         card = board.cards.get(card_id)
         if not card:
             return {'message': 'No intake card found'}, 400
+        elif card.stage >= 2:
+            return {'message': 'Application has already been submitted'}, 400
 
         # parses form data to fill the card description
         capabilities = ['- '+v for k,v in form_data.items()

--- a/resources/FormAssembly.py
+++ b/resources/FormAssembly.py
@@ -92,6 +92,7 @@ class TalentProgramApp(Resource):
         capabilities_str = '\n'.join(capabilities)
         programs = [v for k,v in form_data.items() if 'programs' in k]
         programs_str = '\n'.join(['- ' + p for p in programs ])
+        new_labels = set(card.label_names + programs)
         if form_data.get('mayoral_eligible'):
             mayoral_eligible = form_data.get('mayoral_eligible')
         else:
@@ -136,7 +137,7 @@ class TalentProgramApp(Resource):
             url=f"https://app.formassembly.com/responses/view/{form_data['response_id']}",
             name='Full Response'
         )
-        card.set_labels(programs)
+        card.set_labels(new_labels)
 
         # moves card and updates program_contact to stage 2
         program_contact.update(**{'stage': 2})

--- a/tests/trello_integration_test.py
+++ b/tests/trello_integration_test.py
@@ -74,14 +74,14 @@ def test_talent_intake(app):
 
     for attachment in TALENT_INTAKE_ATTACHMENTS:
         response = card.remove_attachment(attachment)
-    card.set_labels(remove_all=True)
+    card.set_labels(label_names=['New'])
     card.move_card(started_list)
 
     board = Board(query_board_data(board_id))
     card = board.cards.get(card_id)
 
     assert card.attachments == {}
-    assert card.label_names == []
+    assert card.label_names == ['New']
     assert card.stage == 1
 
     url = '/api/form-assembly/talent-app/'
@@ -95,6 +95,7 @@ def test_talent_intake(app):
         board = Board(query_board_data(board_id))
         card = board.cards.get(card_id)
         assert card.stage == 2
+        assert 'New' in card.label_names
         for label in TALENT_INTAKE_LABELS[1:]:
             assert label in card.label_names
         assert 'Race' in card.desc

--- a/tests/trello_integration_test.py
+++ b/tests/trello_integration_test.py
@@ -112,6 +112,37 @@ def test_talent_intake(app):
         )
         data = json.loads(response.data)['data']
 
+def test_resubmit_approved_app(app):
+    mimetype = 'application/x-www-form-urlencoded'
+    headers = {
+        'Content-Type': mimetype,
+        'Accept': mimetype,
+    }
+
+    card_id = '5e4af2d6fc3c0954ff187ddc'
+
+    board_id = TALENT_INTAKE_BOARDS['local']
+    board = Board(query_board_data(board_id))
+    card = board.cards.get(card_id)
+    approved_list = board.lists['stage'][3]
+    card.move_card(approved_list)
+
+    board = Board(query_board_data(board_id))
+    card = board.cards.get(card_id)
+    assert card.stage == 3
+
+    url = '/api/form-assembly/talent-app/'
+    data = (
+        'contact_id=123&program_id=1&first_name=Billy&last_name=Daly&email=billy%40example.com&phone=9085784622&street1=2401+Liberty+Heights+Ave&street2=Suite+2730&city=Baltimore&state=MD&postal_code=21215&equity=Race&effectiveness=Effectiveness&programs%5B0%5D=Fellowship&programs%5B1%5D=JHU+-+Carey&programs%5B2%5D=Mayoral+Fellowship&programs%5B3%5D=PFP&programs%5B4%5D=PA&programs%5B5%5D=I%27d+like+some+help+figuring+this+out&mayoral_eligible=Yes&experience=0-2+years&capabilities%5B0%5D=Advocacy+and+Public+Policy&capabilities%5B1%5D=Community+Engagement+and+Outreach&capabilities%5B2%5D=Data+Analysis&capabilities%5B3%5D=Fundraising+and+Development&capabilities%5B4%5D=Marketing+and+Public+Relations&alum_radio=No&race_all=American+Indian+or+Alaskan+Native&gender=Male&pronouns=He%2FHim&response_id=160140910'
+    )
+
+    with app.test_client() as client:
+        response = client.post(url, data=data, headers=headers)
+        pprint(response.json)
+        assert response.status_code == 400
+        message = json.loads(response.data)['message']
+        assert message == 'Application has already been submitted'
+
 # TODO: Add trello specific checks
 def test_create_program_contact_with_contact(app):
     mimetype = 'application/json'

--- a/tests/trello_integration_test.py
+++ b/tests/trello_integration_test.py
@@ -74,14 +74,14 @@ def test_talent_intake(app):
 
     for attachment in TALENT_INTAKE_ATTACHMENTS:
         response = card.remove_attachment(attachment)
-    card.set_labels(label_names=['New'])
+    card.set_labels(label_names=['New', 'Fellowship'])
     card.move_card(started_list)
 
     board = Board(query_board_data(board_id))
     card = board.cards.get(card_id)
 
     assert card.attachments == {}
-    assert card.label_names == ['New']
+    assert card.label_names == ['New', 'Fellowship']
     assert card.stage == 1
 
     url = '/api/form-assembly/talent-app/'


### PR DESCRIPTION
Adds the following patches to existing bugs:

- Preserves existing labels on the card when an application is submitted
- Checks to see whether an application has already been submitted, and if so returns a `400` status code and an error message when trying to resubmit