### PR TITLE
Bug programs completed nullable

### DIFF
--- a/models/profile_model.py
+++ b/models/profile_model.py
@@ -295,10 +295,11 @@ class ProfileSchema(Schema):
     hear_about_us_other = fields.String(allow_none=True)
     previous_bcorps_program = fields.String(allow_none=True)
     needs_help_programs = fields.String(allow_none=True)
-    address_primary = fields.Nested(ContactAddressSchema)
-    race = fields.Nested(RaceSchema)
-    roles = fields.Nested(RoleChoiceSchema)
-    programs_completed = fields.Nested(ProgramsCompletedSchema)
+    address_primary = fields.Nested(ContactAddressSchema, allow_none=True)
+    race = fields.Nested(RaceSchema, allow_none=True)
+    roles = fields.Nested(RoleChoiceSchema, allow_none=True)
+    programs_completed = fields.Nested(ProgramsCompletedSchema,
+                                       allow_none=True)
 
     class Meta:
         unknown = EXCLUDE

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1416,6 +1416,29 @@ def test_put_program_apps_interested(app):
         data = response.json['data']
         assert data == PROGRAM_APPS['obama_get']
 
+def test_put_programs_completed_nullable(app):
+    url = '/api/contacts/123/about-me'
+    update = CONTACT_PROFILE['billy_update'].copy()
+    update['programs_completed'] = None
+
+    mimetype = 'application/json'
+    headers = {
+        'Content-Type': mimetype,
+        'Accept': mimetype
+    }
+
+    billy = Contact.query.get(123)
+    assert billy.profile.programs_completed is not None
+
+    with app.test_client() as client:
+        response = client.put(url, data=json.dumps(update),
+                              headers=headers)
+        pprint(response.json)
+        assert response.status_code == 200
+        billy = Contact.query.get(123)
+        assert billy.profile.programs_completed is not None
+
+
 @pytest.mark.parametrize(
     "url,update,query,test",
     [('/api/contacts/123/',


### PR DESCRIPTION
Fixes bug with `PUT contacts/<contact_id>/about-me` which didn't allow the `programs_completed` field to be null in the payload