### PR TITLE
Feature endpoint removal

### DIFF
--- a/api.py
+++ b/api.py
@@ -9,11 +9,7 @@ from resources.Contacts import (
     ContactFull,
     ContactApproveMany
 )
-from resources.Tag import TagAll, TagOne, TagItemAll, TagItemOne # TODO: DELETE THIS
 from resources.Experience import ExperienceAll, ExperienceOne
-from resources.Achievement import AchievementAll # TODO: DELETE THIS
-from resources.Resume import ResumeAll, ResumeOne, GenerateResume # TODO: DELETE THIS
-from resources.Resume import ResumeSectionAll, ResumeSectionOne # TODO: DELETE THIS
 from resources.Skills import ContactSkills, ContactSkillOne, AutocompleteSkill
 from resources.Capability import (
     CapabilityRecommended,
@@ -107,44 +103,6 @@ api.add_resource(ExperienceAll,
 api.add_resource(ExperienceOne,
                  '/experiences/<int:experience_id>',
                  '/experiences/<int:experience_id>/')
-api.add_resource(TagAll, # TODO: DELETE THIS
-                 '/tags/',
-                 '/tags')
-api.add_resource(TagOne, # TODO: DELETE THIS
-                 '/tags/<int:tag_id>',
-                 '/tags/<int:tag_id>/')
-api.add_resource(TagItemAll, # TODO: DELETE THIS
-                 '/contacts/<int:contact_id>/tags/',
-                 '/contacts/<int:contact_id>/tags')
-api.add_resource(TagItemOne, # TODO: DELETE THIS
-                 '/contacts/<int:contact_id>/tags/<int:tag_id>',
-                 '/contacts/<int:contact_id>/tags/<int:tag_id>/')
-api.add_resource(AchievementAll, # TODO: DELETE THIS
-                 '/contacts/<int:contact_id>/achievements/',
-                 '/contacts/<int:contact_id>/achievements')
-api.add_resource(ResumeAll, # TODO: DELETE THIS
-                 '/contacts/<int:contact_id>/resumes/',
-                 '/contacts/<int:contact_id>/resumes')
-api.add_resource(ResumeOne, # TODO: DELETE THIS
-                 '/resumes/<int:resume_id>/',
-                 '/resumes/<int:resume_id>')
-api.add_resource(ResumeSectionAll, # TODO: DELETE THIS
-                 '/resumes/<int:resume_id>/sections/',
-                 '/resumes/<int:resume_id>/sections')
-api.add_resource(ResumeSectionOne, # TODO: DELETE THIS
-                 '/resumes/<int:resume_id>/sections/<int:section_id>',
-                 '/resumes/<int:resume_id>/sections/<int:section_id>/')
-api.add_resource(GenerateResume, # TODO: DELETE THIS
-                 '/contacts/<int:contact_id>/generate-resume/')
-api.add_resource(ProgramContactAll, # TODO: DELETE THIS
-                 '/contacts/<int:contact_id>/programs',
-                 '/contacts/<int:contact_id>/programs/')
-api.add_resource(ProgramContactOne, # TODO: DELETE THIS
-                 '/contacts/<int:contact_id>/programs/<int:program_id>',
-                 '/contacts/<int:contact_id>/programs/<int:program_id>/')
-api.add_resource(ProgramContactApproveMany, # TODO: DELETE THIS
-                 '/programs/<int:program_id>/contacts/approve-many',
-                 '/programs/<int:program_id>/contacts/approve-many/')
 api.add_resource(OpportunityAppOne,
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>',
                  '/contacts/<int:contact_id>/app/<string:opportunity_id>/')

--- a/change-sets/code-removal.md
+++ b/change-sets/code-removal.md
@@ -1,0 +1,42 @@
+## Staging branch `staging-code-removal`
+Removes sections of the code that are no longer in use
+
+
+### Branch `feature-endpoint-removal`
+Removes endpoints from api.py and the tests that reference those endpoints in test_api.py
+
+#### Changes
+
+- Removes the following endpoints:
+   - `/tags/`
+   - `/tags/<int:tag_id>`
+   - `/contacts/<int:contact_id>/tags/`
+   - `/contacts/<int:contact_id>/tags/<int:tag_id>`
+   - `/contacts/<int:contact_id>/achievements/`
+   - `/contacts/<int:contact_id>/resumes/`
+   - `/resumes/<int:resume_id>/`
+   - `/resumes/<int:resume_id>/sections/`
+   - `/resumes/<int:resume_id>/sections/<int:section_id>`
+   - `/contacts/<int:contact_id>/generate-resume/`
+   - `/contacts/<int:contact_id>/programs`
+   - `/contacts/<int:contact_id>/programs/<int:program_id>`
+   - `/programs/<int:program_id>/contacts/approve-many`
+- Removes the following tests:
+   - `test_put()` for `api/contacts/123/programs/1/`
+   - `test_put_rejects_id_update()` for `/api/contacts/123/programs/1/`
+   - `test_approve_many_program_contacts_new()`
+   - `test_approve_many_program_contacts_existing()`
+   - `test_reapprove_many_program_contacts()`
+   - `test_approve_program_contact_fake_contact()`
+   - `test_get()` for `/api/contacts/123/programs/1`
+   - `test_get_many_unordered()` for `/api/contacts/123/achievements/`
+   - `test_get_many_unordered()` for `/api/contacts/123/programs/`
+   - `test_post()` for `/api/contacts/124/programs/`
+
+
+### Deployment Considerations
+
+- **Heroku Variables:** No
+- **DB Migrations:** No
+- **AuthZ/N Changes:** No
+- **Deployment Sequence:** Frontend first

--- a/change-sets/filter-skills.md
+++ b/change-sets/filter-skills.md
@@ -1,5 +1,5 @@
-## Staging branch `staging-branch-name`
-{{overview of functionality added in this change set}}
+## Staging branch `staging-filter-skills`
+Adds skills as an optional paramater for `POST api/contacts/filter`
 
 ### Changes
 - Removes `trello_check.py` from directory
@@ -7,13 +7,7 @@
 
 ### Deployment Considerations
 
-- **Heroku Variables:** {{Yes/No}}
-    - {{variable 1}}
-    - {{variable 2}}
-- **DB Migrations:** {{Yes/No}}
-    - {{change 1}}
-    - {{change 2}}
-- **AuthZ/N Changes:** {{Yes/No}}
-    - {{change 1}}
-    - {{change 2}}
-- **Deployment Sequence:** {{Backend/Frontend First}}
+- **Heroku Variables:** No
+- **DB Migrations:** No
+- **AuthZ/N Changes:** No
+- **Deployment Sequence:** Backend First


### PR DESCRIPTION
## Staging branch `staging-code-removal`
Removes sections of the code that are no longer in use


### Branch `feature-endpoint-removal`
Removes endpoints from api.py and the tests that reference those endpoints in test_api.py

#### Changes

- Removes the following endpoints:
   - `/tags/`
   - `/tags/<int:tag_id>`
   - `/contacts/<int:contact_id>/tags/`
   - `/contacts/<int:contact_id>/tags/<int:tag_id>`
   - `/contacts/<int:contact_id>/achievements/`
   - `/contacts/<int:contact_id>/resumes/`
   - `/resumes/<int:resume_id>/`
   - `/resumes/<int:resume_id>/sections/`
   - `/resumes/<int:resume_id>/sections/<int:section_id>`
   - `/contacts/<int:contact_id>/generate-resume/`
   - `/contacts/<int:contact_id>/programs`
   - `/contacts/<int:contact_id>/programs/<int:program_id>`
   - `/programs/<int:program_id>/contacts/approve-many`
- Removes the following tests:
   - `test_put()` for `api/contacts/123/programs/1/`
   - `test_put_rejects_id_update()` for `/api/contacts/123/programs/1/`
   - `test_approve_many_program_contacts_new()`
   - `test_approve_many_program_contacts_existing()`
   - `test_reapprove_many_program_contacts()`
   - `test_approve_program_contact_fake_contact()`
   - `test_get()` for `/api/contacts/123/programs/1`
   - `test_get_many_unordered()` for `/api/contacts/123/achievements/`
   - `test_get_many_unordered()` for `/api/contacts/123/programs/`
   - `test_post()` for `/api/contacts/124/programs/`


### Deployment Considerations

- **Heroku Variables:** No
- **DB Migrations:** No
- **AuthZ/N Changes:** No
- **Deployment Sequence:** Frontend first
